### PR TITLE
chore: add benchmark for `.paths_mut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +134,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +210,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +252,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "deser-hjson"
@@ -174,6 +296,12 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -393,6 +521,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +607,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -630,6 +778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +800,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -706,6 +888,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +956,7 @@ name = "rolldown-notify"
 version = "8.2.0"
 dependencies = [
  "bitflags 2.10.0",
+ "criterion",
  "crossbeam-channel",
  "flume",
  "fsevent-sys",
@@ -990,6 +1193,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1432,3 +1655,23 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2021"
 [workspace.dependencies]
 bitflags = "2.7.0"
 crossbeam-channel = "0.5.0"
+criterion = "0.7.0"
 flume = "0.11.1"
 deser-hjson = "2.2.4"
 env_logger = "0.11.2"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -53,8 +53,13 @@ kqueue.workspace = true
 mio.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
+
+[[bench]]
+name = "paths_mut_bench"
+harness = false
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 trash.workspace = true

--- a/notify/benches/paths_mut_bench.rs
+++ b/notify/benches/paths_mut_bench.rs
@@ -1,0 +1,280 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use notify::{RecursiveMode, Watcher};
+use std::fs::File;
+use std::hint::black_box;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Helper function to create N temporary files in multiple directories (sometimes nested)
+fn create_temp_files(dir: &std::path::Path, count: usize) -> Vec<PathBuf> {
+    let mut paths = Vec::with_capacity(count);
+
+    // Create files in multiple directory structures:
+    // - 40% in root directory
+    // - 30% in first-level subdirectories (dir1/, dir2/, dir3/)
+    // - 30% in nested subdirectories (nested/deep1/, nested/deep2/)
+
+    for i in 0..count {
+        let file_path = match i % 10 {
+            0..=3 => {
+                // Root directory (40%)
+                dir.join(format!("file_{}.txt", i))
+            }
+            4..=6 => {
+                // First-level subdirectories (30%)
+                let subdir = dir.join(format!("dir{}", i % 3));
+                std::fs::create_dir_all(&subdir).expect("Failed to create subdirectory");
+                subdir.join(format!("file_{}.txt", i))
+            }
+            _ => {
+                // Nested subdirectories (30%)
+                let nested_dir = dir.join("nested").join(format!("deep{}", i % 2));
+                std::fs::create_dir_all(&nested_dir).expect("Failed to create nested directory");
+                nested_dir.join(format!("file_{}.txt", i))
+            }
+        };
+
+        File::create(&file_path).expect("Failed to create temp file");
+        paths.push(file_path);
+    }
+    paths
+}
+
+/// Benchmark helper: measures paths_mut total time (add all paths + commit)
+fn bench_paths_mut<W: Watcher>(watcher: &mut W, paths: &[PathBuf], mode: RecursiveMode) {
+    let mut paths_mut = watcher.paths_mut();
+    for path in paths {
+        paths_mut.add(path, mode).expect("Failed to add path");
+    }
+    paths_mut.commit().expect("Failed to commit paths");
+}
+
+// INotify benchmarks (Linux/Android)
+#[cfg(target_os = "linux")]
+fn bench_inotify_paths_mut(c: &mut Criterion) {
+    use notify::INotifyWatcher;
+
+    let mut group = c.benchmark_group("inotify_paths_mut");
+
+    for file_count in [100, 500, 1000] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(
+                BenchmarkId::new(mode_str, file_count),
+                &file_count,
+                |b, &count| {
+                    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                    let paths = create_temp_files(temp_dir.path(), count);
+
+                    b.iter(|| {
+                        use std::hint::black_box;
+
+                        let mut watcher =
+                            INotifyWatcher::new(move |_res| {}, notify::Config::default())
+                                .expect("Failed to create watcher");
+
+                        bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+// FSEvent benchmarks (macOS)
+#[cfg(all(target_os = "macos", feature = "macos_fsevent"))]
+fn bench_fsevent_paths_mut(c: &mut Criterion) {
+    use notify::FsEventWatcher;
+
+    let mut group = c.benchmark_group("fsevent_paths_mut");
+
+    for file_count in [100, 500, 1000] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(
+                BenchmarkId::new(mode_str, file_count),
+                &file_count,
+                |b, &count| {
+                    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                    let paths = create_temp_files(temp_dir.path(), count);
+
+                    b.iter(|| {
+                        let mut watcher =
+                            FsEventWatcher::new(move |_res| {}, notify::Config::default())
+                                .expect("Failed to create watcher");
+
+                        bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+// Kqueue benchmarks (macOS with macos_kqueue feature, BSD, iOS)
+#[cfg(any(
+    all(target_os = "macos", feature = "macos_kqueue"),
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+    target_os = "ios"
+))]
+fn bench_kqueue_paths_mut(c: &mut Criterion) {
+    use notify::KqueueWatcher;
+
+    let mut group = c.benchmark_group("kqueue_paths_mut");
+
+    for file_count in [100, 500, 1000] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(
+                BenchmarkId::new(mode_str, file_count),
+                &file_count,
+                |b, &count| {
+                    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                    let paths = create_temp_files(temp_dir.path(), count);
+
+                    b.iter(|| {
+                        let mut watcher =
+                            KqueueWatcher::new(move |_res| {}, notify::Config::default())
+                                .expect("Failed to create watcher");
+
+                        bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+// Windows benchmarks
+#[cfg(target_os = "windows")]
+fn bench_windows_paths_mut(c: &mut Criterion) {
+    use notify::ReadDirectoryChangesWatcher;
+
+    let mut group = c.benchmark_group("windows_paths_mut");
+
+    for file_count in [100, 500, 1000] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(
+                BenchmarkId::new(mode_str, file_count),
+                &file_count,
+                |b, &count| {
+                    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                    let paths = create_temp_files(temp_dir.path(), count);
+
+                    b.iter(|| {
+                        let mut watcher = ReadDirectoryChangesWatcher::new(
+                            move |_res| {},
+                            notify::Config::default(),
+                        )
+                        .expect("Failed to create watcher");
+
+                        bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+// Poll benchmarks (cross-platform)
+fn bench_poll_paths_mut(c: &mut Criterion) {
+    use notify::PollWatcher;
+
+    let mut group = c.benchmark_group("poll_paths_mut");
+
+    for file_count in [100, 500, 1000] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(
+                BenchmarkId::new(mode_str, file_count),
+                &file_count,
+                |b, &count| {
+                    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                    let paths = create_temp_files(temp_dir.path(), count);
+
+                    b.iter(|| {
+                        let mut watcher =
+                            PollWatcher::new(move |_res| {}, notify::Config::default())
+                                .expect("Failed to create watcher");
+
+                        bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+// Configure criterion groups based on platform
+#[cfg(target_os = "linux")]
+criterion_group!(benches, bench_inotify_paths_mut, bench_poll_paths_mut);
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "macos_fsevent",
+    not(feature = "macos_kqueue")
+))]
+criterion_group!(benches, bench_fsevent_paths_mut, bench_poll_paths_mut);
+
+#[cfg(all(target_os = "macos", feature = "macos_kqueue"))]
+criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
+
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+    target_os = "ios"
+))]
+criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
+
+#[cfg(target_os = "windows")]
+criterion_group!(benches, bench_windows_paths_mut, bench_poll_paths_mut);
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+    target_os = "ios"
+)))]
+criterion_group!(benches, bench_poll_paths_mut);
+
+criterion_main!(benches);


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
