### PR TITLE
perf: reuse the same `ReadDirectoryChangesW` handle for watching a file in the same directory

### DIFF
--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -1031,4 +1031,25 @@ pub mod tests {
         ])
         .ensure_no_tail();
     }
+
+    #[test]
+    fn upgrade_to_recursive() {
+        let tmpdir = testdir();
+        let (mut watcher, mut rx) = watcher();
+
+        let path = tmpdir.path().join("upgrade");
+        let deep = tmpdir.path().join("upgrade/deep");
+        let file = tmpdir.path().join("upgrade/deep/file");
+        std::fs::create_dir_all(&deep).expect("create_dir");
+
+        watcher.watch_nonrecursively(&path);
+        std::fs::File::create_new(&file).expect("create");
+        std::fs::remove_file(&file).expect("delete");
+
+        watcher.watch_recursively(&path);
+        std::fs::File::create_new(&file).expect("create");
+
+        rx.wait_ordered_exact([expected(&deep).modify_any(), expected(&file).create_any()])
+            .ensure_no_tail();
+    }
 }


### PR DESCRIPTION
Reuse the handle to reduce the number of handles.
For the `paths_mut` bench which has many files in the same directory, it improves the perf by 30% - 40%.
```
windows_paths_mut/nonrecursive/100
                        time:   [3.1044 ms 3.1738 ms 3.2479 ms]
                        change: [−30.776% −28.596% −26.358%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
windows_paths_mut/recursive/100
                        time:   [2.8929 ms 2.9234 ms 2.9591 ms]
                        change: [−38.235% −36.313% −34.358%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
windows_paths_mut/nonrecursive/500
                        time:   [14.293 ms 14.573 ms 14.863 ms]
                        change: [−36.807% −34.687% −32.563%] (p = 0.00 < 0.05)
                        Performance has improved.
windows_paths_mut/recursive/500
                        time:   [14.296 ms 14.590 ms 14.904 ms]
                        change: [−40.632% −38.698% −36.666%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
windows_paths_mut/nonrecursive/1000
                        time:   [28.555 ms 29.174 ms 29.850 ms]
                        change: [−43.973% −42.293% −40.487%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
windows_paths_mut/recursive/1000
                        time:   [28.275 ms 28.829 ms 29.409 ms]
                        change: [−42.775% −40.867% −38.956%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```