### PR TITLE
fix: emit `remove` event if add watch fails due to non-existing path for kqueue watcher

### DIFF
--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -734,10 +734,7 @@ mod tests {
         std::fs::write(&overwriting_file, "321").expect("write2");
         std::fs::rename(&overwriting_file, &overwritten_file).expect("rename");
 
-        rx.wait_ordered([
-            expected(&overwritten_file).create_file(),
-            expected(tmpdir.path()).modify_data_any(),
-        ]);
+        rx.wait_ordered([expected(&overwritten_file).create_file()]);
     }
 
     #[test]


### PR DESCRIPTION
Emit `remove` event if add watch fails due to non-existing path for kqueue watcher as that means the file is removed.

This PR also separates the paths that are specified from outside and the paths are watched due to internal reasons so that we can emit the events / decide whether the watch is needed properly.