### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rolldown-file-id"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "tempfile",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify"
-version = "8.2.0"
+version = "8.2.1"
 dependencies = [
  "bitflags 2.10.0",
  "criterion",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crossbeam-channel",
  "deser-hjson",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crossbeam-channel",
  "flume",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-types"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "insta",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ criterion = "0.7.0"
 flume = "0.11.1"
 deser-hjson = "2.2.4"
 env_logger = "0.11.2"
-rolldown-file-id = { version = "0.2.3", path = "file-id" }
+rolldown-file-id = { version = "0.2.4", path = "file-id" }
 fsevent-sys = "4.0.0"
 futures = "0.3.30"
 inotify = { version = "0.11.0", default-features = false }
@@ -35,10 +35,10 @@ libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
-rolldown-notify = { version = "8.2.0", path = "notify" }
-rolldown-notify-debouncer-full = { version = "0.6.0", path = "notify-debouncer-full" }
-rolldown-notify-debouncer-mini = { version = "0.7.0", path = "notify-debouncer-mini" }
-rolldown-notify-types = { version = "2.0.0", path = "notify-types" }
+rolldown-notify = { version = "8.2.1", path = "notify" }
+rolldown-notify-debouncer-full = { version = "0.6.1", path = "notify-debouncer-full" }
+rolldown-notify-debouncer-mini = { version = "0.7.1", path = "notify-debouncer-mini" }
+rolldown-notify-types = { version = "2.0.1", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rstest = "0.26.0"
 serde = { version = "1.0.89", features = ["derive"] }

--- a/file-id/CHANGELOG.md
+++ b/file-id/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.4](https://github.com/rolldown/notify/compare/rolldown-file-id-v0.2.3...rolldown-file-id-v0.2.4) - 2025-11-16
+
+### Other
+
+- migrate to rust edition 2024 ([#2](https://github.com/rolldown/notify/pull/2))

--- a/file-id/Cargo.toml
+++ b/file-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-file-id"
-version = "0.2.3"
+version = "0.2.4"
 description = "Utility for reading inode numbers (Linux, MacOS) and file IDs (Windows)"
 documentation = "https://docs.rs/notify"
 readme = "README.md"

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.1](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.0...rolldown-notify-debouncer-full-v0.6.1) - 2025-11-16
+
+### Other
+
+- migrate to rust edition 2024 ([#2](https://github.com/rolldown/notify/pull/2))

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.0"
+version = "0.6.1"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
 authors = ["Daniel Faust <hessijames@gmail.com>"]

--- a/notify-debouncer-mini/CHANGELOG.md
+++ b/notify-debouncer-mini/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.1](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.0...rolldown-notify-debouncer-mini-v0.7.1) - 2025-11-16
+
+### Other
+
+- updated the following local packages: rolldown-notify-types, rolldown-notify

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.0"
+version = "0.7.1"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
 authors = ["Aron Heinecke <Ox0p54r36@t-online.de>"]

--- a/notify-types/CHANGELOG.md
+++ b/notify-types/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.1](https://github.com/rolldown/notify/compare/rolldown-notify-types-v2.0.0...rolldown-notify-types-v2.0.1) - 2025-11-16
+
+### Other
+
+- update rust toolchain to 1.90.0

--- a/notify-types/Cargo.toml
+++ b/notify-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-types"
-version = "2.0.0"
+version = "2.0.1"
 description = "Types used by the notify crate"
 documentation = "https://docs.rs/notify-types"
 readme = "../README.md"

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [8.2.1](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.0...rolldown-notify-v8.2.1) - 2025-11-16
+
+### Fixed
+
+- emit `remove` event if add watch fails due to non-existing path for kqueue watcher ([#6](https://github.com/rolldown/notify/pull/6))
+- throw fsevents stream start error properly ([#4](https://github.com/rolldown/notify/pull/4))
+
+### Other
+
+- add kqueue tests ([#5](https://github.com/rolldown/notify/pull/5))
+- reuse the same `ReadDirectoryChangesW` handle for watching a file in the same directory ([#3](https://github.com/rolldown/notify/pull/3))
+- migrate to rust edition 2024 ([#2](https://github.com/rolldown/notify/pull/2))
+- add benchmark for .paths_mut ([#1](https://github.com/rolldown/notify/pull/1))
+- fix test failure with macOS kqueue
+- add test helpers and tests ([#728](https://github.com/rolldown/notify/pull/728))
+- `FsEventWatcher` crashes when dealing with empty path ([#718](https://github.com/rolldown/notify/pull/718))
+- update rust toolchain to 1.90.0

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify"
-version = "8.2.0"
+version = "8.2.1"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
 readme = "../README.md"


### PR DESCRIPTION



## 🤖 New release

* `rolldown-notify-types`: 2.0.0 -> 2.0.1 (✓ API compatible changes)
* `rolldown-notify`: 8.2.0 -> 8.2.1 (✓ API compatible changes)
* `rolldown-file-id`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `rolldown-notify-debouncer-full`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `rolldown-notify-debouncer-mini`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rolldown-notify-types`

<blockquote>

## [2.0.1](https://github.com/rolldown/notify/compare/rolldown-notify-types-v2.0.0...rolldown-notify-types-v2.0.1) - 2025-11-16

### Other

- update rust toolchain to 1.90.0
</blockquote>

## `rolldown-notify`

<blockquote>

## [8.2.1](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.0...rolldown-notify-v8.2.1) - 2025-11-16

### Fixed

- emit `remove` event if add watch fails due to non-existing path for kqueue watcher ([#6](https://github.com/rolldown/notify/pull/6))
- throw fsevents stream start error properly ([#4](https://github.com/rolldown/notify/pull/4))

### Other

- add kqueue tests ([#5](https://github.com/rolldown/notify/pull/5))
- reuse the same `ReadDirectoryChangesW` handle for watching a file in the same directory ([#3](https://github.com/rolldown/notify/pull/3))
- migrate to rust edition 2024 ([#2](https://github.com/rolldown/notify/pull/2))
- add benchmark for .paths_mut ([#1](https://github.com/rolldown/notify/pull/1))
- fix test failure with macOS kqueue
- add test helpers and tests ([#728](https://github.com/rolldown/notify/pull/728))
- `FsEventWatcher` crashes when dealing with empty path ([#718](https://github.com/rolldown/notify/pull/718))
- update rust toolchain to 1.90.0
</blockquote>

## `rolldown-file-id`

<blockquote>

## [0.2.4](https://github.com/rolldown/notify/compare/rolldown-file-id-v0.2.3...rolldown-file-id-v0.2.4) - 2025-11-16

### Other

- migrate to rust edition 2024 ([#2](https://github.com/rolldown/notify/pull/2))
</blockquote>

## `rolldown-notify-debouncer-full`

<blockquote>

## [0.6.1](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.0...rolldown-notify-debouncer-full-v0.6.1) - 2025-11-16

### Other

- migrate to rust edition 2024 ([#2](https://github.com/rolldown/notify/pull/2))
</blockquote>

## `rolldown-notify-debouncer-mini`

<blockquote>

## [0.7.1](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.0...rolldown-notify-debouncer-mini-v0.7.1) - 2025-11-16

### Other

- updated the following local packages: rolldown-notify-types, rolldown-notify
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).