### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify"
-version = "8.2.1"
+version = "8.2.2"
 dependencies = [
  "bitflags 2.10.0",
  "criterion",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crossbeam-channel",
  "deser-hjson",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "crossbeam-channel",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
-rolldown-notify = { version = "8.2.1", path = "notify" }
-rolldown-notify-debouncer-full = { version = "0.6.1", path = "notify-debouncer-full" }
-rolldown-notify-debouncer-mini = { version = "0.7.1", path = "notify-debouncer-mini" }
+rolldown-notify = { version = "8.2.2", path = "notify" }
+rolldown-notify-debouncer-full = { version = "0.6.2", path = "notify-debouncer-full" }
+rolldown-notify-debouncer-mini = { version = "0.7.2", path = "notify-debouncer-mini" }
 rolldown-notify-types = { version = "2.0.1", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rstest = "0.26.0"

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.1...rolldown-notify-debouncer-full-v0.6.2) - 2025-11-21
+
+### Other
+
+- updated the following local packages: rolldown-notify
+
 ## [0.6.1](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.0...rolldown-notify-debouncer-full-v0.6.1) - 2025-11-16
 
 ### Other

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.1"
+version = "0.6.2"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
 authors = ["Daniel Faust <hessijames@gmail.com>"]

--- a/notify-debouncer-mini/CHANGELOG.md
+++ b/notify-debouncer-mini/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.1...rolldown-notify-debouncer-mini-v0.7.2) - 2025-11-21
+
+### Other
+
+- updated the following local packages: rolldown-notify
+
 ## [0.7.1](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.0...rolldown-notify-debouncer-mini-v0.7.1) - 2025-11-16
 
 ### Other

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.1"
+version = "0.7.2"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
 authors = ["Aron Heinecke <Ox0p54r36@t-online.de>"]

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.2.2](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.1...rolldown-notify-v8.2.2) - 2025-11-21
+
+### Fixed
+
+- remove watch handles after file deletion for inotify ([#15](https://github.com/rolldown/notify/pull/15))
+- avoid watching file under a directory that is watched for inotify backend ([#14](https://github.com/rolldown/notify/pull/14))
+
+### Other
+
+- verify watch handles for kqueue ([#13](https://github.com/rolldown/notify/pull/13))
+- verify watch handles for Windows backend ([#12](https://github.com/rolldown/notify/pull/12))
+- verify watch handles for inotify ([#11](https://github.com/rolldown/notify/pull/11))
+- separate watch_handles from watchers for inotify backend ([#9](https://github.com/rolldown/notify/pull/9))
+
 ## [8.2.1](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.0...rolldown-notify-v8.2.1) - 2025-11-16
 
 ### Fixed

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify"
-version = "8.2.1"
+version = "8.2.2"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
 readme = "../README.md"


### PR DESCRIPTION



## 🤖 New release

* `rolldown-notify`: 8.2.1 -> 8.2.2 (✓ API compatible changes)
* `rolldown-notify-debouncer-mini`: 0.7.1 -> 0.7.2
* `rolldown-notify-debouncer-full`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `rolldown-notify`

<blockquote>

## [8.2.2](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.1...rolldown-notify-v8.2.2) - 2025-11-21

### Fixed

- remove watch handles after file deletion for inotify ([#15](https://github.com/rolldown/notify/pull/15))
- avoid watching file under a directory that is watched for inotify backend ([#14](https://github.com/rolldown/notify/pull/14))

### Other

- verify watch handles for kqueue ([#13](https://github.com/rolldown/notify/pull/13))
- verify watch handles for Windows backend ([#12](https://github.com/rolldown/notify/pull/12))
- verify watch handles for inotify ([#11](https://github.com/rolldown/notify/pull/11))
- separate watch_handles from watchers for inotify backend ([#9](https://github.com/rolldown/notify/pull/9))
</blockquote>

## `rolldown-notify-debouncer-mini`

<blockquote>

## [0.7.2](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.1...rolldown-notify-debouncer-mini-v0.7.2) - 2025-11-21

### Other

- updated the following local packages: rolldown-notify
</blockquote>

## `rolldown-notify-debouncer-full`

<blockquote>

## [0.6.2](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.1...rolldown-notify-debouncer-full-v0.6.2) - 2025-11-21

### Other

- updated the following local packages: rolldown-notify
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).