### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify"
-version = "8.2.2"
+version = "8.2.3"
 dependencies = [
  "bitflags 2.10.0",
  "criterion",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "crossbeam-channel",
  "deser-hjson",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "crossbeam-channel",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
-rolldown-notify = { version = "8.2.2", path = "notify" }
-rolldown-notify-debouncer-full = { version = "0.6.2", path = "notify-debouncer-full" }
-rolldown-notify-debouncer-mini = { version = "0.7.2", path = "notify-debouncer-mini" }
+rolldown-notify = { version = "8.2.3", path = "notify" }
+rolldown-notify-debouncer-full = { version = "0.6.3", path = "notify-debouncer-full" }
+rolldown-notify-debouncer-mini = { version = "0.7.3", path = "notify-debouncer-mini" }
 rolldown-notify-types = { version = "2.0.1", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rstest = "0.26.0"

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.2...rolldown-notify-debouncer-full-v0.6.3) - 2025-11-21
+
+### Other
+
+- updated the following local packages: rolldown-notify
+
 ## [0.6.2](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.1...rolldown-notify-debouncer-full-v0.6.2) - 2025-11-21
 
 ### Other

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.2"
+version = "0.6.3"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
 authors = ["Daniel Faust <hessijames@gmail.com>"]

--- a/notify-debouncer-mini/CHANGELOG.md
+++ b/notify-debouncer-mini/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.2...rolldown-notify-debouncer-mini-v0.7.3) - 2025-11-21
+
+### Other
+
+- updated the following local packages: rolldown-notify
+
 ## [0.7.2](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.1...rolldown-notify-debouncer-mini-v0.7.2) - 2025-11-21
 
 ### Other

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.2"
+version = "0.7.3"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
 authors = ["Aron Heinecke <Ox0p54r36@t-online.de>"]

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.2.3](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.2...rolldown-notify-v8.2.3) - 2025-11-21
+
+### Fixed
+
+- align the behavior of kqueue backend more with others ([#16](https://github.com/rolldown/notify/pull/16))
+
 ## [8.2.2](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.1...rolldown-notify-v8.2.2) - 2025-11-21
 
 ### Fixed

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify"
-version = "8.2.2"
+version = "8.2.3"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
 readme = "../README.md"


### PR DESCRIPTION



## 🤖 New release

* `rolldown-notify`: 8.2.2 -> 8.2.3 (✓ API compatible changes)
* `rolldown-notify-debouncer-mini`: 0.7.2 -> 0.7.3
* `rolldown-notify-debouncer-full`: 0.6.2 -> 0.6.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `rolldown-notify`

<blockquote>

## [8.2.3](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.2...rolldown-notify-v8.2.3) - 2025-11-21

### Fixed

- align the behavior of kqueue backend more with others ([#16](https://github.com/rolldown/notify/pull/16))
</blockquote>

## `rolldown-notify-debouncer-mini`

<blockquote>

## [0.7.3](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.2...rolldown-notify-debouncer-mini-v0.7.3) - 2025-11-21

### Other

- updated the following local packages: rolldown-notify
</blockquote>

## `rolldown-notify-debouncer-full`

<blockquote>

## [0.6.3](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.2...rolldown-notify-debouncer-full-v0.6.3) - 2025-11-21

### Other

- updated the following local packages: rolldown-notify
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).