### PR TITLE
feat!: change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode`

### DIFF
--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -2,7 +2,7 @@ use futures::{
     SinkExt, StreamExt,
     channel::mpsc::{Receiver, channel},
 };
-use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, Event, RecommendedWatcher, WatchMode, Watcher};
 use std::path::Path;
 
 /// Async, futures channel based event watching
@@ -41,7 +41,7 @@ async fn async_watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
+    watcher.watch(path.as_ref(), WatchMode::recursive())?;
 
     while let Some(res) = rx.next().await {
         match res {

--- a/examples/debouncer_full.rs
+++ b/examples/debouncer_full.rs
@@ -1,6 +1,6 @@
 use std::{fs, thread, time::Duration};
 
-use notify::RecursiveMode;
+use notify::WatchMode;
 use notify_debouncer_full::new_debouncer;
 use tempfile::tempdir;
 
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // no specific tickrate, max debounce time 2 seconds
     let mut debouncer = new_debouncer(Duration::from_secs(2), None, tx)?;
 
-    debouncer.watch(dir.path(), RecursiveMode::Recursive)?;
+    debouncer.watch(dir.path(), WatchMode::recursive())?;
 
     // print all events and errors
     for result in rx {

--- a/examples/debouncer_mini.rs
+++ b/examples/debouncer_mini.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, time::Duration};
 
-use notify::RecursiveMode;
+use notify::WatchMode;
 use notify_debouncer_mini::new_debouncer;
 
 /// Example for debouncer mini
@@ -37,7 +37,7 @@ fn main() {
 
     debouncer
         .watcher()
-        .watch(Path::new("."), RecursiveMode::Recursive)
+        .watch(Path::new("."), WatchMode::recursive())
         .unwrap();
 
     // print all events, non returning

--- a/examples/debouncer_mini_custom.rs
+++ b/examples/debouncer_mini_custom.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, time::Duration};
 
-use notify::{self, RecursiveMode};
+use notify::{self, WatchMode};
 use notify_debouncer_mini::{Config, new_debouncer_opt};
 
 /// Debouncer with custom backend and waiting for exit
@@ -28,7 +28,7 @@ fn main() {
 
     debouncer
         .watcher()
-        .watch(Path::new("."), RecursiveMode::Recursive)
+        .watch(Path::new("."), WatchMode::recursive())
         .unwrap();
     // print all events, non returning
     for result in rx {

--- a/examples/hot_reload_tide/src/main.rs
+++ b/examples/hot_reload_tide/src/main.rs
@@ -3,7 +3,7 @@
 // you can edit the configuration and the app will pick up changes without the need to restart it.
 // This concept is known as hot-reloading.
 use hot_reload_tide::messages::{load_config, Config};
-use notify::{Error, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Error, Event, RecommendedWatcher, WatchMode, Watcher};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tide::{Body, Response};
@@ -40,7 +40,7 @@ async fn main() -> tide::Result<()> {
             }
         },notify::Config::default())?;
 
-    watcher.watch(Path::new(CONFIG_PATH), RecursiveMode::Recursive)?;
+    watcher.watch(Path::new(CONFIG_PATH), WatchMode::recursive())?;
 
     // We set up a web server using [Tide](https://github.com/http-rs/tide)
     let mut app = tide::with_state(config);

--- a/examples/monitor_debounced.rs
+++ b/examples/monitor_debounced.rs
@@ -1,4 +1,4 @@
-use notify::RecursiveMode;
+use notify::WatchMode;
 use notify_debouncer_full::new_debouncer;
 use std::{path::Path, time::Duration};
 
@@ -26,7 +26,7 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    debouncer.watch(path.as_ref(), RecursiveMode::Recursive)?;
+    debouncer.watch(path.as_ref(), WatchMode::recursive())?;
 
     // print all events and errors
     for result in rx {

--- a/examples/monitor_raw.rs
+++ b/examples/monitor_raw.rs
@@ -1,4 +1,4 @@
-use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, RecommendedWatcher, WatchMode, Watcher};
 use std::path::Path;
 
 fn main() {
@@ -24,7 +24,7 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
+    watcher.watch(path.as_ref(), WatchMode::recursive())?;
 
     for res in rx {
         match res {

--- a/examples/poll_sysfs.rs
+++ b/examples/poll_sysfs.rs
@@ -3,7 +3,7 @@
 /// This example can't be demonstrated under windows, it might be relevant for network shares
 #[cfg(not(target_os = "windows"))]
 fn not_windows_main() -> notify::Result<()> {
-    use notify::{Config, PollWatcher, RecursiveMode, Watcher};
+    use notify::{Config, PollWatcher, Watcher};
     use std::path::Path;
     use std::time::Duration;
 
@@ -36,7 +36,9 @@ fn not_windows_main() -> notify::Result<()> {
     let mut watcher = PollWatcher::new(tx, config)?;
     for path in paths {
         // watch all paths
-        watcher.watch(&path, RecursiveMode::Recursive)?;
+
+        use notify::WatchMode;
+        watcher.watch(&path, WatchMode::recursive())?;
     }
     // print all events, never returns
     for res in rx {

--- a/examples/pollwatcher_manual.rs
+++ b/examples/pollwatcher_manual.rs
@@ -1,4 +1,4 @@
-use notify::{Config, PollWatcher, RecursiveMode, Watcher};
+use notify::{Config, PollWatcher, WatchMode, Watcher};
 use std::path::Path;
 
 // Example for the PollWatcher with manual polling.
@@ -24,7 +24,7 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
+    watcher.watch(path.as_ref(), WatchMode::recursive())?;
 
     // run event receiver on a different thread, we want this one for user input
     std::thread::spawn(move || {

--- a/examples/pollwatcher_scan.rs
+++ b/examples/pollwatcher_scan.rs
@@ -1,4 +1,4 @@
-use notify::{Config, PollWatcher, RecursiveMode, Watcher, poll::ScanEvent};
+use notify::{Config, PollWatcher, WatchMode, Watcher, poll::ScanEvent};
 use std::path::Path;
 
 // Example for the pollwatcher scan callback feature.
@@ -42,7 +42,7 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
+    watcher.watch(path.as_ref(), WatchMode::recursive())?;
 
     for res in rx {
         match res {

--- a/examples/watcher_kind.rs
+++ b/examples/watcher_kind.rs
@@ -18,7 +18,7 @@ fn main() {
 
     // watch some stuff
     watcher
-        .watch(Path::new("."), RecursiveMode::Recursive)
+        .watch(Path::new("."), WatchMode::recursive())
         .unwrap();
 
     // just print all events, this blocks forever

--- a/notify-debouncer-full/src/cache.rs
+++ b/notify-debouncer-full/src/cache.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use file_id::{FileId, get_file_id};
-use notify::RecursiveMode;
+use notify::{RecursiveMode, WatchMode};
 use walkdir::WalkDir;
 
 /// The interface of a file ID cache.
@@ -19,7 +19,7 @@ pub trait FileIdCache {
     /// Add a new path to the cache or update its value.
     ///
     /// This will be called if a new file or directory is created or if an existing file is overridden.
-    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode);
+    fn add_path(&mut self, path: &Path, watch_mode: WatchMode);
 
     /// Remove a path from the cache.
     ///
@@ -32,9 +32,9 @@ pub trait FileIdCache {
     /// The root paths are passed as argument, so the implementer doesn't have to store them.
     ///
     /// The default implementation calls `add_path` for each root path.
-    fn rescan(&mut self, root_paths: &[(PathBuf, RecursiveMode)]) {
-        for (path, recursive_mode) in root_paths {
-            self.add_path(path, *recursive_mode);
+    fn rescan(&mut self, root_paths: &[(PathBuf, WatchMode)]) {
+        for (path, watch_mode) in root_paths {
+            self.add_path(path, *watch_mode);
         }
     }
 }
@@ -64,8 +64,8 @@ impl FileIdCache for FileIdMap {
         self.paths.get(path)
     }
 
-    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode) {
-        let is_recursive = recursive_mode == RecursiveMode::Recursive;
+    fn add_path(&mut self, path: &Path, watch_mode: WatchMode) {
+        let is_recursive = watch_mode.recursive_mode == RecursiveMode::Recursive;
 
         for (path, file_id) in WalkDir::new(path)
             .follow_links(true)
@@ -104,7 +104,7 @@ impl FileIdCache for NoCache {
         Option::<&FileId>::None
     }
 
-    fn add_path(&mut self, _path: &Path, _recursive_mode: RecursiveMode) {}
+    fn add_path(&mut self, _path: &Path, _watch_mode: WatchMode) {}
 
     fn remove_path(&mut self, _path: &Path) {}
 }

--- a/notify-debouncer-full/src/testing.rs
+++ b/notify-debouncer-full/src/testing.rs
@@ -6,7 +6,7 @@ use std::{
 
 use file_id::FileId;
 use notify::{
-    Error, ErrorKind, Event, EventKind, RecursiveMode,
+    Error, ErrorKind, Event, EventKind, WatchMode,
     event::{
         AccessKind, AccessMode, CreateKind, DataChange, Flag, MetadataKind, ModifyKind, RemoveKind,
         RenameMode,
@@ -294,10 +294,10 @@ impl FileIdCache for TestCache {
         self.paths.get(path)
     }
 
-    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode) {
+    fn add_path(&mut self, path: &Path, watch_mode: WatchMode) {
         for (file_path, file_id) in &self.file_system {
             if file_path == path
-                || (file_path.starts_with(path) && recursive_mode == RecursiveMode::Recursive)
+                || (file_path.starts_with(path) && watch_mode == WatchMode::recursive())
             {
                 self.paths.insert(file_path.clone(), *file_id);
             }

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //!   // Add a path to be watched. All files and directories at that path and
 //!   // below will be monitored for changes.
-//!   debouncer.watcher().watch(Path::new("."), RecursiveMode::Recursive).unwrap();
+//!   debouncer.watcher().watch(Path::new("."), WatchMode::recursive()).unwrap();
 //!
 //!   // note that dropping the debouncer (as will happen here) also ends the debouncer
 //!   // thus this demo would need an endless loop to keep running
@@ -410,7 +410,7 @@ pub fn new_debouncer<F: DebounceEventHandler>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notify::RecursiveMode;
+    use notify::WatchMode;
     use std::fs;
     use tempfile::tempdir;
 
@@ -423,7 +423,7 @@ mod tests {
         let mut debouncer = new_debouncer(Duration::from_secs(1), tx)?;
         debouncer
             .watcher()
-            .watch(dir.path(), RecursiveMode::Recursive)?;
+            .watch(dir.path(), WatchMode::recursive())?;
 
         // create a new file
         let file_path = dir.path().join("file.txt");

--- a/notify/benches/paths_mut_bench.rs
+++ b/notify/benches/paths_mut_bench.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use notify::{RecursiveMode, Watcher};
+use notify::{RecursiveMode, TargetMode, WatchMode, Watcher};
 use std::fs::File;
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -44,7 +44,15 @@ fn create_temp_files(dir: &std::path::Path, count: usize) -> Vec<PathBuf> {
 fn bench_paths_mut<W: Watcher>(watcher: &mut W, paths: &[PathBuf], mode: RecursiveMode) {
     let mut paths_mut = watcher.paths_mut();
     for path in paths {
-        paths_mut.add(path, mode).expect("Failed to add path");
+        paths_mut
+            .add(
+                path,
+                WatchMode {
+                    recursive_mode: mode,
+                    target_mode: TargetMode::TrackPath,
+                },
+            )
+            .expect("Failed to add path");
     }
     paths_mut.commit().expect("Failed to commit paths");
 }

--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -2,6 +2,33 @@
 
 use std::time::Duration;
 
+/// Indicates how the path should be watched
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+pub struct WatchMode {
+    /// Indicates whether to watch sub-directories as well
+    pub recursive_mode: RecursiveMode,
+    /// Indicates what happens when the relationship of the physical entity and the file path changes
+    pub target_mode: TargetMode,
+}
+
+impl WatchMode {
+    /// Creates a WatchMode that watches directories recursively and tracks the file path
+    pub fn recursive() -> Self {
+        Self {
+            recursive_mode: RecursiveMode::Recursive,
+            target_mode: TargetMode::TrackPath,
+        }
+    }
+
+    /// Creates a WatchMode that watches only the provided directory and tracks the file path
+    pub fn non_recursive() -> Self {
+        Self {
+            recursive_mode: RecursiveMode::NonRecursive,
+            target_mode: TargetMode::TrackPath,
+        }
+    }
+}
+
 /// Indicates whether only the provided directory or its sub-directories as well should be watched
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum RecursiveMode {
@@ -19,6 +46,25 @@ impl RecursiveMode {
             RecursiveMode::NonRecursive => false,
         }
     }
+}
+
+/// Indicates what happens when the relationship of the physical entity and the file path changes
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum TargetMode {
+    /// Tracks the file path.
+    ///
+    /// If the underlying physical entity (inode/File ID) at this path is replaced
+    /// (e.g., by a move/rename operation), the watch continues to monitor the new entity
+    /// that now occupies the path.
+    ///
+    /// TODO: This is not yet implemented. Currently, all backends behave as NoTrack.
+    TrackPath,
+
+    /// Does not track the file path, nor the physical entity.
+    ///
+    /// If the underlying physical entity (inode/File ID) is replaced
+    /// (e.g., by a move/rename operation), the watch stops monitoring.
+    NoTrack,
 }
 
 /// Watcher Backend configuration

--- a/notify/src/null.rs
+++ b/notify/src/null.rs
@@ -4,7 +4,7 @@
 
 use crate::Config;
 
-use super::{RecursiveMode, Result, Watcher};
+use super::{Result, WatchMode, Watcher};
 use std::path::Path;
 
 /// Stub `Watcher` implementation
@@ -14,7 +14,7 @@ use std::path::Path;
 pub struct NullWatcher;
 
 impl Watcher for NullWatcher {
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch(&mut self, path: &Path, watch_mode: WatchMode) -> Result<()> {
         Ok(())
     }
 

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -3,7 +3,7 @@
 //! Checks the `watch`ed paths periodically to detect changes. This implementation only uses
 //! Rust stdlib APIs and should work on all of the platforms it supports.
 
-use crate::{Config, Error, EventHandler, Receiver, RecursiveMode, Sender, Watcher, unbounded};
+use crate::{Config, Error, EventHandler, Receiver, Sender, WatchMode, Watcher, unbounded};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -609,7 +609,7 @@ impl PollWatcher {
     ///
     /// QUESTION: this function never return an Error, is it as intend?
     /// Please also consider the IO Error event problem.
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) {
+    fn watch_inner(&mut self, path: &Path, watch_mode: WatchMode) {
         // HINT: Make sure always lock in the same order to avoid deadlock.
         //
         // FIXME: inconsistent: some place mutex poison cause panic, some place just ignore.
@@ -620,7 +620,7 @@ impl PollWatcher {
 
             let watch_data = data_builder.build_watch_data(
                 path.to_path_buf(),
-                recursive_mode.is_recursive(),
+                watch_mode.recursive_mode.is_recursive(),
                 self.follow_sylinks,
             );
 
@@ -651,8 +651,8 @@ impl Watcher for PollWatcher {
         Self::new(event_handler, config)
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> crate::Result<()> {
-        self.watch_inner(path, recursive_mode);
+    fn watch(&mut self, path: &Path, watch_mode: WatchMode) -> crate::Result<()> {
+        self.watch_inner(path, watch_mode);
 
         Ok(())
     }

--- a/notify/src/test.rs
+++ b/notify/src/test.rs
@@ -12,7 +12,7 @@ use std::{
 
 use notify_types::event::Event;
 
-use crate::{Config, Error, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher, WatcherKind};
+use crate::{Config, Error, PollWatcher, RecommendedWatcher, WatchMode, Watcher, WatcherKind};
 use pretty_assertions::assert_eq;
 
 pub use expect::*;
@@ -236,17 +236,17 @@ pub struct TestWatcher<W> {
 
 impl<W: Watcher> TestWatcher<W> {
     pub fn watch_recursively(&mut self, path: impl AsRef<Path>) {
-        self.watch(path, RecursiveMode::Recursive);
+        self.watch(path, WatchMode::recursive());
     }
 
     pub fn watch_nonrecursively(&mut self, path: impl AsRef<Path>) {
-        self.watch(path, RecursiveMode::NonRecursive);
+        self.watch(path, WatchMode::non_recursive());
     }
 
-    pub fn watch(&mut self, path: impl AsRef<Path>, recursive_mode: RecursiveMode) {
+    pub fn watch(&mut self, path: impl AsRef<Path>, watch_mode: WatchMode) {
         let path = path.as_ref();
         self.watcher
-            .watch(path, recursive_mode)
+            .watch(path, watch_mode)
             .unwrap_or_else(|e| panic!("Unable to watch {:?}: {e:#?}", path))
     }
 


### PR DESCRIPTION
`WatchMode` is a struct that includes `RecursiveMode` and `TargetMode`. `TargetMode` allows specifying the behavior when the relationship between the physical entity and the file path changes.