### PR TITLE
feat: implement `TargetMode::TrackPath` for inotify

### DIFF
--- a/notify/src/test.rs
+++ b/notify/src/test.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashSet,
     fmt::Debug,
+    fs,
     ops::Deref,
     path::{Path, PathBuf},
     sync::mpsc::{self, RecvTimeoutError},
@@ -360,6 +361,13 @@ impl TestDir {
     pub fn to_path_buf(&self) -> PathBuf {
         self.path.to_path_buf()
     }
+
+    pub fn parent_path_buf(&self) -> PathBuf {
+        self.path
+            .parent()
+            .expect("TestDir has no parent")
+            .to_path_buf()
+    }
 }
 
 impl AsRef<Path> for TestDir {
@@ -377,7 +385,12 @@ pub fn testdir() -> TestDir {
             dir.path()
         )
     });
-    TestDir { _dir: dir, path }
+    let nested_path = path.join("nested");
+    fs::create_dir(&nested_path).expect("Unable to create nested directory");
+    TestDir {
+        _dir: dir,
+        path: nested_path,
+    }
 }
 
 /// Collection to store [`notify_types::event::EventAttributes::tracker`]


### PR DESCRIPTION
Implements `TargetMode::TrackPath` behavior for inotify backend.

- watching non-existent nested paths is not supported yet (skipped test is added)
- filtering out some unrelated events is not implemented