### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify"
-version = "8.2.4"
+version = "9.0.0"
 dependencies = [
  "bitflags 2.10.0",
  "criterion",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "crossbeam-channel",
  "deser-hjson",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "crossbeam-channel",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
-rolldown-notify = { version = "8.2.4", path = "notify" }
-rolldown-notify-debouncer-full = { version = "0.6.4", path = "notify-debouncer-full" }
-rolldown-notify-debouncer-mini = { version = "0.7.4", path = "notify-debouncer-mini" }
+rolldown-notify = { version = "9.0.0", path = "notify" }
+rolldown-notify-debouncer-full = { version = "0.7.0", path = "notify-debouncer-full" }
+rolldown-notify-debouncer-mini = { version = "0.8.0", path = "notify-debouncer-mini" }
 rolldown-notify-types = { version = "2.0.1", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rstest = "0.26.0"

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.4...rolldown-notify-debouncer-full-v0.7.0) - 2025-11-23
+
+### Added
+
+- [**breaking**] change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode` ([#21](https://github.com/rolldown/notify/pull/21))
+
 ## [0.6.4](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.3...rolldown-notify-debouncer-full-v0.6.4) - 2025-11-23
 
 ### Other

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.4"
+version = "0.7.0"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
 authors = ["Daniel Faust <hessijames@gmail.com>"]

--- a/notify-debouncer-mini/CHANGELOG.md
+++ b/notify-debouncer-mini/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.4...rolldown-notify-debouncer-mini-v0.8.0) - 2025-11-23
+
+### Added
+
+- [**breaking**] change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode` ([#21](https://github.com/rolldown/notify/pull/21))
+
 ## [0.7.4](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.3...rolldown-notify-debouncer-mini-v0.7.4) - 2025-11-23
 
 ### Other

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-mini"
-version = "0.7.4"
+version = "0.8.0"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
 authors = ["Aron Heinecke <Ox0p54r36@t-online.de>"]

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.4...rolldown-notify-v9.0.0) - 2025-11-23
+
+### Added
+
+- implement `TargetMode::TrackPath` for kqueue ([#25](https://github.com/rolldown/notify/pull/25))
+- implement `TargetMode::TrackPath` for fsevent ([#27](https://github.com/rolldown/notify/pull/27))
+- implement `TargetMode::TrackPath` for Windows ([#23](https://github.com/rolldown/notify/pull/23))
+- implement `TargetMode::TrackPath` for inotify ([#22](https://github.com/rolldown/notify/pull/22))
+- [**breaking**] change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode` ([#21](https://github.com/rolldown/notify/pull/21))
+
+### Other
+
+- update TargetMode comment ([#36](https://github.com/rolldown/notify/pull/36))
+- add optional expected events to reduce flakiness ([#31](https://github.com/rolldown/notify/pull/31))
+- add `TargetMode` related tests for polling watcher ([#30](https://github.com/rolldown/notify/pull/30))
+- wait a short period before checking whether no events were received ([#29](https://github.com/rolldown/notify/pull/29))
+- add optional expected events to reduce flakiness ([#28](https://github.com/rolldown/notify/pull/28))
+
 ## [8.2.4](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.3...rolldown-notify-v8.2.4) - 2025-11-23
 
 ### Fixed

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify"
-version = "8.2.4"
+version = "9.0.0"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
 readme = "../README.md"


### PR DESCRIPTION



## 🤖 New release

* `rolldown-notify`: 8.2.4 -> 9.0.0 (✓ API compatible changes)
* `rolldown-notify-debouncer-mini`: 0.7.4 -> 0.8.0 (✓ API compatible changes)
* `rolldown-notify-debouncer-full`: 0.6.4 -> 0.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rolldown-notify`

<blockquote>

## [9.0.0](https://github.com/rolldown/notify/compare/rolldown-notify-v8.2.4...rolldown-notify-v9.0.0) - 2025-11-23

### Added

- implement `TargetMode::TrackPath` for kqueue ([#25](https://github.com/rolldown/notify/pull/25))
- implement `TargetMode::TrackPath` for fsevent ([#27](https://github.com/rolldown/notify/pull/27))
- implement `TargetMode::TrackPath` for Windows ([#23](https://github.com/rolldown/notify/pull/23))
- implement `TargetMode::TrackPath` for inotify ([#22](https://github.com/rolldown/notify/pull/22))
- [**breaking**] change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode` ([#21](https://github.com/rolldown/notify/pull/21))

### Other

- update TargetMode comment ([#36](https://github.com/rolldown/notify/pull/36))
- add optional expected events to reduce flakiness ([#31](https://github.com/rolldown/notify/pull/31))
- add `TargetMode` related tests for polling watcher ([#30](https://github.com/rolldown/notify/pull/30))
- wait a short period before checking whether no events were received ([#29](https://github.com/rolldown/notify/pull/29))
- add optional expected events to reduce flakiness ([#28](https://github.com/rolldown/notify/pull/28))
</blockquote>

## `rolldown-notify-debouncer-mini`

<blockquote>

## [0.8.0](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.7.4...rolldown-notify-debouncer-mini-v0.8.0) - 2025-11-23

### Added

- [**breaking**] change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode` ([#21](https://github.com/rolldown/notify/pull/21))
</blockquote>

## `rolldown-notify-debouncer-full`

<blockquote>

## [0.7.0](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.6.4...rolldown-notify-debouncer-full-v0.7.0) - 2025-11-23

### Added

- [**breaking**] change `Watcher::watch` to take `WatchMode` instead of `RecursiveMode` ([#21](https://github.com/rolldown/notify/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).