### PR TITLE
test: wait a short period before checking whether no events were received

### DIFF
--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -885,8 +885,7 @@ mod tests {
 
         std::fs::write(&file, "").expect("write");
 
-        thread::sleep(Duration::from_millis(10));
-        // rx.ensure_empty(); // TODO: should unwatch
+        // rx.ensure_empty_with_wait(); // TODO: should unwatch
     }
 
     #[test]
@@ -1013,8 +1012,7 @@ mod tests {
 
         std::fs::create_dir(&path).expect("create_dir2");
 
-        thread::sleep(Duration::from_millis(10));
-        // rx.ensure_empty(); // TODO: should unwatch
+        // rx.ensure_empty_with_wait(); // TODO: should unwatch
     }
 
     #[test]

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1302,7 +1302,7 @@ mod tests {
 
         std::fs::write(&file, "").expect("write");
 
-        rx.ensure_empty();
+        rx.ensure_empty_with_wait();
     }
 
     #[test]
@@ -1558,7 +1558,7 @@ mod tests {
 
         std::fs::create_dir(&path).expect("create_dir2");
 
-        rx.ensure_empty();
+        rx.ensure_empty_with_wait();
     }
 
     #[test]

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -1025,7 +1025,7 @@ mod tests {
 
         std::fs::write(&file, "").expect("write");
 
-        rx.ensure_empty();
+        rx.ensure_empty_with_wait();
     }
 
     #[test]
@@ -1211,7 +1211,7 @@ mod tests {
 
         std::fs::create_dir(&path).expect("create_dir2");
 
-        rx.ensure_empty();
+        rx.ensure_empty_with_wait();
     }
 
     #[test]

--- a/notify/src/test.rs
+++ b/notify/src/test.rs
@@ -156,6 +156,12 @@ impl Receiver {
         }
     }
 
+    /// Ensures, that the receiver part is empty. It waits for a short period and then checks the channel
+    pub fn ensure_empty_with_wait(&mut self) {
+        thread::sleep(Duration::from_millis(10));
+        self.ensure_empty();
+    }
+
     /// see [`sleep_until`].
     ///
     /// it uses timeout from [`Self::timeout`]

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -1053,7 +1053,7 @@ pub mod tests {
 
         // std::fs::write(&file, "").expect("write");
 
-        // rx.ensure_empty();
+        // rx.ensure_empty_with_wait();
     }
 
     #[test]
@@ -1284,7 +1284,7 @@ pub mod tests {
 
         std::fs::create_dir(&path).expect("create_dir2");
 
-        rx.ensure_empty();
+        rx.ensure_empty_with_wait();
     }
 
     #[test]


### PR DESCRIPTION
So that the assertion doesn't miss events that happens after a short period.
