### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rolldown-file-id"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "serde",
  "tempfile",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify"
-version = "10.2.0"
+version = "10.3.0"
 dependencies = [
  "bitflags 2.10.0",
  "criterion",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-full"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "crossbeam-channel",
  "deser-hjson",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify-debouncer-mini"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "crossbeam-channel",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ criterion = "0.7.0"
 flume = "0.11.1"
 deser-hjson = "2.2.4"
 tracing-subscriber = "0.3.20"
-rolldown-file-id = { version = "0.2.6", path = "file-id" }
+rolldown-file-id = { version = "0.2.7", path = "file-id" }
 objc2-core-foundation = { version = "0.3.2", default-features = false }
 objc2-core-services = { version = "0.3.2", default-features = false }
 futures = "0.3.30"
@@ -94,9 +94,9 @@ libc = "0.2.4"
 tracing = "0.1.41"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
-rolldown-notify = { version = "10.2.0", path = "notify" }
-rolldown-notify-debouncer-full = { version = "0.7.5", path = "notify-debouncer-full" }
-rolldown-notify-debouncer-mini = { version = "0.8.5", path = "notify-debouncer-mini" }
+rolldown-notify = { version = "10.3.0", path = "notify" }
+rolldown-notify-debouncer-full = { version = "0.7.6", path = "notify-debouncer-full" }
+rolldown-notify-debouncer-mini = { version = "0.8.6", path = "notify-debouncer-mini" }
 rolldown-notify-types = { version = "2.0.2", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rstest = "0.26.0"

--- a/file-id/CHANGELOG.md
+++ b/file-id/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/rolldown/notify/compare/rolldown-file-id-v0.2.6...rolldown-file-id-v0.2.7) - 2026-03-13
+
+### Other
+
+- add wasi tests ([#69](https://github.com/rolldown/notify/pull/69))
+
 ## [0.2.6](https://github.com/rolldown/notify/compare/rolldown-file-id-v0.2.5...rolldown-file-id-v0.2.6) - 2026-03-06
 
 ### Added

--- a/file-id/Cargo.toml
+++ b/file-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-file-id"
-version = "0.2.6"
+version = "0.2.7"
 description = "Utility for reading inode numbers (Linux, MacOS) and file IDs (Windows)"
 documentation = "https://docs.rs/notify"
 readme = "README.md"

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.7.5...rolldown-notify-debouncer-full-v0.7.6) - 2026-03-13
+
+### Other
+
+- updated the following local packages: rolldown-notify, rolldown-file-id
+
 ## [0.7.5](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.7.4...rolldown-notify-debouncer-full-v0.7.5) - 2026-03-06
 
 ### Added

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-full"
-version = "0.7.5"
+version = "0.7.6"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
 authors = ["Daniel Faust <hessijames@gmail.com>"]

--- a/notify-debouncer-mini/CHANGELOG.md
+++ b/notify-debouncer-mini/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.8.5...rolldown-notify-debouncer-mini-v0.8.6) - 2026-03-13
+
+### Other
+
+- updated the following local packages: rolldown-notify
+
 ## [0.8.5](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.8.4...rolldown-notify-debouncer-mini-v0.8.5) - 2026-03-06
 
 ### Other

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify-debouncer-mini"
-version = "0.8.5"
+version = "0.8.6"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
 authors = ["Aron Heinecke <Ox0p54r36@t-online.de>"]

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.3.0](https://github.com/rolldown/notify/compare/rolldown-notify-v10.2.0...rolldown-notify-v10.3.0) - 2026-03-13
+
+### Added
+
+- *(inotify)* capture `UNMOUNT` event
+
+### Fixed
+
+- *(fsevent)* set `is: clone` info for more `IS_CLONE` events
+- *(windows)* normalize event paths ([#74](https://github.com/rolldown/notify/pull/74))
+- *(fsevent)* handle `ROOT_CHANGED` for non-existing path
+- *(inotify)* do not modify inotify watcher when unmounting
+- *(fsevent)* do not panic on invalid inputs
+- handle `ROOT_CHANGED` nicely
+- `target_os` entry for `dragonflyBSD` in `Cargo.toml`
+- add `kFSEventStreamCreateFlagWatchRoot` to `FSEvents` stream flags ([#769](https://github.com/rolldown/notify/pull/769))
+- `FsEvenWatcher` remove event ordering
+
+### Other
+
+- tweak `rename_self_file_no_track` polling test to reduce flakiness ([#72](https://github.com/rolldown/notify/pull/72))
+- improve watcher docs
+- *(macos)* document APFS behavior as known issues
+- fix flaky PollWatcher tests
+- add wasi tests ([#69](https://github.com/rolldown/notify/pull/69))
+
 ## [10.2.0](https://github.com/rolldown/notify/compare/rolldown-notify-v10.1.0...rolldown-notify-v10.2.0) - 2026-03-06
 
 ### Added

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown-notify"
-version = "10.2.0"
+version = "10.3.0"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
 readme = "../README.md"


### PR DESCRIPTION



## 🤖 New release

* `rolldown-notify`: 10.2.0 -> 10.3.0 (✓ API compatible changes)
* `rolldown-file-id`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `rolldown-notify-debouncer-mini`: 0.8.5 -> 0.8.6
* `rolldown-notify-debouncer-full`: 0.7.5 -> 0.7.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `rolldown-notify`

<blockquote>

## [10.3.0](https://github.com/rolldown/notify/compare/rolldown-notify-v10.2.0...rolldown-notify-v10.3.0) - 2026-03-13

### Added

- *(inotify)* capture `UNMOUNT` event

### Fixed

- *(fsevent)* set `is: clone` info for more `IS_CLONE` events
- *(windows)* normalize event paths ([#74](https://github.com/rolldown/notify/pull/74))
- *(fsevent)* handle `ROOT_CHANGED` for non-existing path
- *(inotify)* do not modify inotify watcher when unmounting
- *(fsevent)* do not panic on invalid inputs
- handle `ROOT_CHANGED` nicely
- `target_os` entry for `dragonflyBSD` in `Cargo.toml`
- add `kFSEventStreamCreateFlagWatchRoot` to `FSEvents` stream flags ([#769](https://github.com/rolldown/notify/pull/769))
- `FsEvenWatcher` remove event ordering

### Other

- tweak `rename_self_file_no_track` polling test to reduce flakiness ([#72](https://github.com/rolldown/notify/pull/72))
- improve watcher docs
- *(macos)* document APFS behavior as known issues
- fix flaky PollWatcher tests
- add wasi tests ([#69](https://github.com/rolldown/notify/pull/69))
</blockquote>

## `rolldown-file-id`

<blockquote>

## [0.2.7](https://github.com/rolldown/notify/compare/rolldown-file-id-v0.2.6...rolldown-file-id-v0.2.7) - 2026-03-13

### Other

- add wasi tests ([#69](https://github.com/rolldown/notify/pull/69))
</blockquote>

## `rolldown-notify-debouncer-mini`

<blockquote>

## [0.8.6](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-mini-v0.8.5...rolldown-notify-debouncer-mini-v0.8.6) - 2026-03-13

### Other

- updated the following local packages: rolldown-notify
</blockquote>

## `rolldown-notify-debouncer-full`

<blockquote>

## [0.7.6](https://github.com/rolldown/notify/compare/rolldown-notify-debouncer-full-v0.7.5...rolldown-notify-debouncer-full-v0.7.6) - 2026-03-13

### Other

- updated the following local packages: rolldown-notify, rolldown-file-id
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).