### PR TITLE
ci: use GitHub App token for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: oxc-project/release-plz@44b98e8dda1a7783d4ec2ef66e2f37a3e8c1c759 # v1.0.4
         with:
-          PAT: ${{ secrets.ROLLDOWN_BOT_PAT }}
+          PAT: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- generate a GitHub App token in the release workflow
- pass the generated token to `oxc-project/release-plz` instead of `secrets.ROLLDOWN_BOT_PAT`

## Verification
- `rg --hidden -n "ROLLDOWN_BOT_PAT" /Users/boshen/github/rolldown --glob '!**/.git/**' --glob '!**/node_modules/**' --glob '!**/target/**' --glob '!benchmark-results-storage/**'`
- `git diff --check -- .github/workflows/release.yml`
- YAML parse sanity check