### PR TITLE
ci: use bot PAT for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        id: app-token
-        with:
-          client-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: oxc-project/release-plz@e2b12f55ad64a22af8e93634b94439c42913afca # v1.0.6
         with:
-          PAT: ${{ steps.app-token.outputs.token }}
+          PAT: ${{ secrets.ROLLDOWN_BOT_PAT }}


### PR DESCRIPTION
## Summary
- remove the GitHub App token creation step from the release workflow
- pass `secrets.ROLLDOWN_BOT_PAT` directly to `release-plz`

## Why
The release workflow failed on `main` because `actions/create-github-app-token` could not find an installation for `rolldown/notify`:

`Not Found - https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app`

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`