### PR TITLE
ci: scope release GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: oxc-project/release-plz@e2b12f55ad64a22af8e93634b94439c42913afca # v1.0.6
         with:


### PR DESCRIPTION
## Summary
- keep the release workflow on `actions/create-github-app-token`
- scope the generated token through the repository owner installation and back to `notify`
- request only the contents and pull request permissions needed by release-plz

## Why
The release job failed before checkout because `actions/create-github-app-token` defaulted to the current repository lookup and GitHub returned 404 for `/repos/rolldown/notify/installation`. Setting `owner` and `repositories` makes the action create the token from the owner installation instead of relying on the repository-installation lookup path.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`
- `git diff --check -- .github/workflows/release.yml`

`actionlint` is not installed locally, so it was not run.