### PR TITLE
chore: exclude `hot_reload_tide` example from renovate

### DIFF
--- a/examples/hot_reload_tide/Cargo.toml
+++ b/examples/hot_reload_tide/Cargo.toml
@@ -11,7 +11,7 @@ tide = "0.16.0"
 async-std = { version = "1.6.0", features = ["attributes"] }
 serde_json = "1.0"
 serde = "1.0.115"
-notify = { path = "../../notify", features = ["serde"] }
+rolldown-notify = { path = "../../notify", features = ["serde"] }
 
 # required to prevent mixing with workspace
 # hack to prevent cargo audit from catching this

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate"],
-  "forkProcessing": "enabled"
+  "forkProcessing": "enabled",
+  "ignorePaths": ["examples/hot_reload_tide"]
 }


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
