### PR TITLE
feat: consolidate paths further more for fsevents backend if needed

### DIFF
--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -2,6 +2,10 @@
 
 use std::time::Duration;
 
+/// Default maximum number of paths to pass to FSEvents, chosen to stay
+/// well under the macOS default file descriptor soft limit (256).
+pub const DEFAULT_MAX_FSEVENT_PATHS: usize = 128;
+
 /// Indicates how the path should be watched
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct WatchMode {
@@ -128,6 +132,9 @@ pub struct Config {
     compare_contents: bool,
 
     follow_symlinks: bool,
+
+    /// See [Config::with_max_fsevent_paths]
+    max_fsevent_paths: usize,
 }
 
 impl Config {
@@ -203,6 +210,31 @@ impl Config {
     pub fn follow_symlinks(&self) -> bool {
         self.follow_symlinks
     }
+
+    /// For the [`FsEventWatcher`](crate::FsEventWatcher) backend.
+    ///
+    /// Maximum number of paths to pass to FSEvents. When the number of
+    /// watched paths exceeds this limit, the watcher automatically watches
+    /// parent directories instead of individual paths to reduce file
+    /// descriptor usage.
+    ///
+    /// The default is [`DEFAULT_MAX_FSEVENT_PATHS`]. Set to `0` to disable
+    /// consolidation.
+    ///
+    /// This can't be changed during runtime.
+    #[must_use]
+    pub fn with_max_fsevent_paths(mut self, max_paths: usize) -> Self {
+        self.max_fsevent_paths = max_paths;
+        self
+    }
+
+    /// Returns current setting.
+    ///
+    /// `0` means consolidation is disabled.
+    #[must_use]
+    pub fn max_fsevent_paths(&self) -> usize {
+        self.max_fsevent_paths
+    }
 }
 
 impl Default for Config {
@@ -211,6 +243,7 @@ impl Default for Config {
             poll_interval: Some(Duration::from_secs(30)),
             compare_contents: false,
             follow_symlinks: true,
+            max_fsevent_paths: DEFAULT_MAX_FSEVENT_PATHS,
         }
     }
 }

--- a/notify/src/consolidating_path_trie.rs
+++ b/notify/src/consolidating_path_trie.rs
@@ -38,6 +38,28 @@ impl<T> PathTrieNode<T> {
     pub fn descendants(&self) -> impl Iterator<Item = (PathBuf, &T)> {
         PathTrieIter::new(self)
     }
+
+    /// Count the total number of valued nodes in this subtree.
+    pub fn count_values(&self) -> usize {
+        let mut count = usize::from(self.value.is_some());
+        for (_, child) in &self.children {
+            count += child.count_values();
+        }
+        count
+    }
+
+    /// Return the depth of the deepest valued node in this subtree.
+    pub fn max_value_depth(&self, current_depth: usize) -> usize {
+        let mut max = if self.value.is_some() {
+            current_depth
+        } else {
+            0
+        };
+        for (_, child) in &self.children {
+            max = max.max(child.max_value_depth(current_depth + 1));
+        }
+        max
+    }
 }
 
 #[derive(Debug)]
@@ -171,18 +193,40 @@ impl<'a, T> PathTrieIter<'a, T> {
     }
 }
 
+/// Consolidate all valued descendants of nodes at `target_depth` into
+/// the node itself. Does not consolidate nodes at depth < `min_depth`.
+fn consolidate_at_depth<V: Default>(
+    node: &mut PathTrieNode<V>,
+    current_depth: usize,
+    target_depth: usize,
+    min_depth: usize,
+) {
+    if current_depth == target_depth && current_depth >= min_depth {
+        if node.count_values() > 0 {
+            node.set_value(V::default());
+            node.remove_children();
+        }
+        return;
+    }
+    for (_, child) in &mut node.children {
+        consolidate_at_depth(child, current_depth + 1, target_depth, min_depth);
+    }
+}
+
 pub struct ConsolidatingPathTrie {
     children_consolidation: bool,
-
+    /// Maximum number of paths before consolidation. 0 means disabled.
+    max_paths: usize,
     trie: PathTrie<()>,
 }
 
 impl ConsolidatingPathTrie {
     const CHILDREN_CONSOLIDATION_THRESHOLD: usize = 10;
 
-    pub fn new(children_consolidation: bool) -> Self {
+    pub fn new(children_consolidation: bool, max_paths: usize) -> Self {
         Self {
             children_consolidation,
+            max_paths,
             trie: PathTrie::new(),
         }
     }
@@ -209,7 +253,78 @@ impl ConsolidatingPathTrie {
         }
     }
 
-    pub fn values(&self) -> Vec<PathBuf> {
+    /// Find the depth below which consolidation is safe.
+    ///
+    /// Walks from the trie root following single-child nodes until hitting
+    /// a node with multiple children (a divergence point). If there are
+    /// multiple branching levels, the first divergence is protected to
+    /// prevent merging distinct subtrees. If there's only one branching
+    /// level (single chain to leaf fan-out), consolidation is allowed
+    /// at the branching point.
+    ///
+    /// Example 1: watching `/a/x/y`, `/a/x/z`, `/b/w/v`
+    ///   First fork at `/` (depth 1), children `a` and `b` have subtrees.
+    ///   Returns 2 (`/a` and `/b` are never merged into `/`).
+    ///
+    /// Example 2: watching `/root/a/b/file0` .. `/root/a/b/file19`
+    ///   First fork at `b` (depth 4), all children are leaves.
+    ///   Returns 4 (files can be merged into `/root/a/b`).
+    fn min_consolidation_depth(&self) -> usize {
+        let mut node = &self.trie.root;
+        let mut depth = 0;
+        let first_branch_depth;
+
+        // Walk single-child nodes to find first divergence
+        loop {
+            if node.children.len() <= 1 {
+                if let Some((_, child)) = node.children.first() {
+                    node = child;
+                    depth += 1;
+                } else {
+                    return 0;
+                }
+            } else {
+                first_branch_depth = depth;
+                break;
+            }
+        }
+
+        // Check if any child of the branching node has further depth
+        // (i.e., children that are not leaves). If so, the branches represent
+        // distinct subtrees that should be protected from cross-subtree merging.
+        let children_have_depth = node
+            .children
+            .iter()
+            .any(|(_, child)| !child.children.is_empty());
+
+        if children_have_depth {
+            // Children have subtrees: protect the divergence point
+            first_branch_depth + 1
+        } else {
+            // All children are leaves: single level, allow consolidation
+            first_branch_depth
+        }
+    }
+
+    pub fn values(&mut self) -> Vec<PathBuf> {
+        if self.max_paths > 0 {
+            let max_paths = self.max_paths;
+            let mut count = self.trie.root.count_values();
+            if count > max_paths {
+                let min_depth = self.min_consolidation_depth();
+                let mut depth = self.trie.root.max_value_depth(0);
+
+                // O(D × N) where D = depth range, N = trie nodes. Could be O(N)
+                // with a single bottom-up DFS pass, but this only runs once per
+                // stream restart which already recreates the FSEventStream.
+                while count > max_paths && depth > min_depth {
+                    consolidate_at_depth(&mut self.trie.root, 0, depth - 1, min_depth);
+                    count = self.trie.root.count_values();
+                    depth -= 1;
+                }
+            }
+        }
+
         self.trie
             .root
             .descendants()
@@ -241,7 +356,7 @@ mod tests {
     #[test]
     fn consolidate_no_siblings() {
         for children_consolidation in [true, false] {
-            let mut ct = ConsolidatingPathTrie::new(children_consolidation);
+            let mut ct = ConsolidatingPathTrie::new(children_consolidation, 0);
             ct.insert(PathBuf::from("/a/b"));
             ct.insert(PathBuf::from("/a/c"));
             assert_eq!(
@@ -254,7 +369,7 @@ mod tests {
     #[test]
     fn consolidate_no_siblings2() {
         for children_consolidation in [true, false] {
-            let mut ct = ConsolidatingPathTrie::new(children_consolidation);
+            let mut ct = ConsolidatingPathTrie::new(children_consolidation, 0);
             ct.insert(PathBuf::from("/a/b1"));
             ct.insert(PathBuf::from("/a/b2"));
             assert_eq!(
@@ -267,7 +382,7 @@ mod tests {
     #[test]
     fn consolidate_children() {
         for children_consolidation in [true, false] {
-            let mut ct = ConsolidatingPathTrie::new(children_consolidation);
+            let mut ct = ConsolidatingPathTrie::new(children_consolidation, 0);
             ct.insert(PathBuf::from("/a/b"));
             ct.insert(PathBuf::from("/a/b/c"));
             assert_eq!(ct.values(), vec![PathBuf::from("/a/b")]);
@@ -277,7 +392,7 @@ mod tests {
     #[test]
     fn consolidate_parent() {
         for children_consolidation in [true, false] {
-            let mut ct = ConsolidatingPathTrie::new(children_consolidation);
+            let mut ct = ConsolidatingPathTrie::new(children_consolidation, 0);
             ct.insert(PathBuf::from("/a/b/c"));
             ct.insert(PathBuf::from("/a/b"));
             assert_eq!(ct.values(), vec![PathBuf::from("/a/b")]);
@@ -286,13 +401,13 @@ mod tests {
 
     #[test]
     fn consolidate_to_single_parent() {
-        let mut cr = ConsolidatingPathTrie::new(true);
+        let mut cr = ConsolidatingPathTrie::new(true, 0);
         for i in 1..=ConsolidatingPathTrie::CHILDREN_CONSOLIDATION_THRESHOLD {
             cr.insert(PathBuf::from(format!("/a/b/c{i}")));
         }
         assert_eq!(cr.values(), vec![PathBuf::from("/a/b")]);
 
-        let mut cr = ConsolidatingPathTrie::new(false);
+        let mut cr = ConsolidatingPathTrie::new(false, 0);
         for i in 1..=ConsolidatingPathTrie::CHILDREN_CONSOLIDATION_THRESHOLD {
             cr.insert(PathBuf::from(format!("/a/b/c{i}")));
         }
@@ -301,7 +416,7 @@ mod tests {
 
     #[test]
     fn consolidate_to_single_parent_nested1() {
-        let mut cr = ConsolidatingPathTrie::new(true);
+        let mut cr = ConsolidatingPathTrie::new(true, 0);
         for i in 1..ConsolidatingPathTrie::CHILDREN_CONSOLIDATION_THRESHOLD {
             cr.insert(PathBuf::from(format!("/a/b/c{i}")));
         }
@@ -313,7 +428,7 @@ mod tests {
 
     #[test]
     fn consolidate_to_single_parent_nested2() {
-        let mut cr = ConsolidatingPathTrie::new(true);
+        let mut cr = ConsolidatingPathTrie::new(true, 0);
         cr.insert(PathBuf::from("/a/b/c1"));
         cr.insert(PathBuf::from("/a/b/c2"));
         for i in 1..=ConsolidatingPathTrie::CHILDREN_CONSOLIDATION_THRESHOLD {
@@ -327,5 +442,177 @@ mod tests {
                 PathBuf::from("/a/b/c3")
             ]
         );
+    }
+
+    #[test]
+    fn count_values_basic() {
+        let mut t = PathTrie::new();
+        t.insert(PathBuf::from("/a"), ());
+        t.insert(PathBuf::from("/a/b/c"), ());
+        t.insert(PathBuf::from("/d"), ());
+        assert_eq!(t.root.count_values(), 3);
+    }
+
+    #[test]
+    fn max_value_depth_basic() {
+        let mut t = PathTrie::new();
+        t.insert(PathBuf::from("/a"), ());
+        t.insert(PathBuf::from("/a/b/c"), ());
+        t.insert(PathBuf::from("/d/e"), ());
+        assert_eq!(t.root.max_value_depth(0), 4);
+    }
+
+    #[test]
+    fn max_value_depth_flat() {
+        let mut t = PathTrie::new();
+        t.insert(PathBuf::from("/a"), ());
+        t.insert(PathBuf::from("/b"), ());
+        assert_eq!(t.root.max_value_depth(0), 2);
+    }
+
+    #[test]
+    fn consolidate_at_depth_basic() {
+        let mut t = PathTrie::new();
+        t.insert(PathBuf::from("/a/b/c1"), ());
+        t.insert(PathBuf::from("/a/b/c2"), ());
+        t.insert(PathBuf::from("/d/e"), ());
+
+        consolidate_at_depth(&mut t.root, 0, 3, 0);
+
+        let paths: Vec<PathBuf> = t.root.descendants().map(|(p, ())| p).collect();
+        assert_eq!(paths, vec![PathBuf::from("/a/b"), PathBuf::from("/d/e")]);
+    }
+
+    #[test]
+    fn consolidate_at_depth_respects_min_depth() {
+        let mut t = PathTrie::new();
+        t.insert(PathBuf::from("/a/b"), ());
+        t.insert(PathBuf::from("/a/c"), ());
+
+        // Try to consolidate at depth 2 (/a level) but min_depth is 3
+        consolidate_at_depth(&mut t.root, 0, 2, 3);
+
+        let paths: Vec<PathBuf> = t.root.descendants().map(|(p, ())| p).collect();
+        // Should NOT consolidate because depth 2 < min_depth 3
+        assert_eq!(paths, vec![PathBuf::from("/a/b"), PathBuf::from("/a/c")]);
+    }
+
+    #[test]
+    fn max_paths_no_consolidation_when_under_limit() {
+        let mut ct = ConsolidatingPathTrie::new(false, 5);
+        ct.insert(PathBuf::from("/a/b"));
+        ct.insert(PathBuf::from("/a/c"));
+        ct.insert(PathBuf::from("/d/e"));
+        assert_eq!(ct.values().len(), 3);
+    }
+
+    #[test]
+    fn max_paths_consolidates_deepest_first() {
+        let mut ct = ConsolidatingPathTrie::new(false, 3);
+        ct.insert(PathBuf::from("/a/b/c1"));
+        ct.insert(PathBuf::from("/a/b/c2"));
+        ct.insert(PathBuf::from("/a/b/c3"));
+        ct.insert(PathBuf::from("/d/e"));
+        ct.insert(PathBuf::from("/f/g"));
+
+        let values = ct.values();
+        assert_eq!(values.len(), 3);
+        assert!(values.contains(&PathBuf::from("/a/b")));
+        assert!(values.contains(&PathBuf::from("/d/e")));
+        assert!(values.contains(&PathBuf::from("/f/g")));
+    }
+
+    #[test]
+    fn max_paths_respects_subtree_roots() {
+        // Two distinct subtrees: /a/... and /b/...
+        // Even with aggressive consolidation, /a and /b should remain separate
+        let mut ct = ConsolidatingPathTrie::new(false, 2);
+        ct.insert(PathBuf::from("/a/x/y1"));
+        ct.insert(PathBuf::from("/a/x/y2"));
+        ct.insert(PathBuf::from("/b/z/w1"));
+        ct.insert(PathBuf::from("/b/z/w2"));
+
+        let values = ct.values();
+        // Consolidates within each subtree but never merges /a and /b into /
+        assert_eq!(values.len(), 2);
+        assert!(values.contains(&PathBuf::from("/a/x")));
+        assert!(values.contains(&PathBuf::from("/b/z")));
+    }
+
+    #[test]
+    fn max_paths_cannot_consolidate_above_divergence() {
+        // Paths diverge at / into /a and /b, each with deeper structure
+        // max_paths=1 is impossible to satisfy without going above divergence
+        let mut ct = ConsolidatingPathTrie::new(false, 1);
+        ct.insert(PathBuf::from("/a/x/y"));
+        ct.insert(PathBuf::from("/b/z/w"));
+
+        let values = ct.values();
+        // Best we can do is /a and /b (2 paths) — can't merge to /
+        assert_eq!(values.len(), 2);
+        assert!(values.contains(&PathBuf::from("/a")));
+        assert!(values.contains(&PathBuf::from("/b")));
+    }
+
+    #[test]
+    fn max_paths_multi_level_consolidation() {
+        let mut ct = ConsolidatingPathTrie::new(false, 2);
+        ct.insert(PathBuf::from("/a/b/c/d1"));
+        ct.insert(PathBuf::from("/a/b/c/d2"));
+        ct.insert(PathBuf::from("/a/b/e/f1"));
+        ct.insert(PathBuf::from("/a/b/e/f2"));
+        ct.insert(PathBuf::from("/x/y"));
+
+        let values = ct.values();
+        assert_eq!(values.len(), 2);
+        assert!(values.contains(&PathBuf::from("/a/b")));
+        assert!(values.contains(&PathBuf::from("/x/y")));
+    }
+
+    #[test]
+    fn max_paths_large_scale_multiple_roots() {
+        let mut ct = ConsolidatingPathTrie::new(false, 1024);
+
+        for root in ["a", "b", "c", "d"] {
+            for i in 0..500 {
+                ct.insert(PathBuf::from(format!("/{root}/sub{}/file{i}", i % 10)));
+            }
+        }
+
+        let values = ct.values();
+        assert!(
+            values.len() <= 1024,
+            "Expected <= 1024 paths, got {}",
+            values.len()
+        );
+        assert!(values.iter().any(|p| p.starts_with("/a")));
+        assert!(values.iter().any(|p| p.starts_with("/b")));
+        assert!(values.iter().any(|p| p.starts_with("/c")));
+        assert!(values.iter().any(|p| p.starts_with("/d")));
+    }
+
+    #[test]
+    fn max_paths_single_root_deep() {
+        let mut ct = ConsolidatingPathTrie::new(false, 5);
+
+        for i in 0..20 {
+            ct.insert(PathBuf::from(format!("/root/a/b/file{i}")));
+        }
+
+        let values = ct.values();
+        assert!(
+            values.len() <= 5,
+            "Expected <= 5 paths, got {}",
+            values.len()
+        );
+    }
+
+    #[test]
+    fn max_paths_none_no_consolidation() {
+        let mut ct = ConsolidatingPathTrie::new(false, 0);
+        for i in 0..100 {
+            ct.insert(PathBuf::from(format!("/root/file{i}")));
+        }
+        assert_eq!(ct.values().len(), 100);
     }
 }

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -70,6 +70,7 @@ pub struct FsEventWatcher {
     event_handler: Arc<Mutex<dyn EventHandler>>,
     runloop: Option<(cf::CFRetained<cf::CFRunLoop>, thread::JoinHandle<()>)>,
     watches: HashMap<PathBuf, bool, FxBuildHasher>,
+    max_fsevent_paths: usize,
 }
 
 impl fmt::Debug for FsEventWatcher {
@@ -353,7 +354,10 @@ impl PathsMut for FsEventPathsMut<'_> {
 }
 
 impl FsEventWatcher {
-    fn from_event_handler(event_handler: Arc<Mutex<dyn EventHandler>>) -> Self {
+    fn from_event_handler(
+        event_handler: Arc<Mutex<dyn EventHandler>>,
+        max_fsevent_paths: usize,
+    ) -> Self {
         FsEventWatcher {
             paths: cf::CFMutableArray::empty(),
             since_when: fs::kFSEventStreamEventIdSinceNow,
@@ -364,6 +368,7 @@ impl FsEventWatcher {
             event_handler,
             runloop: None,
             watches: HashMap::default(),
+            max_fsevent_paths,
         }
     }
 
@@ -434,7 +439,7 @@ impl FsEventWatcher {
 
     fn update_paths_based_on_watches(&mut self) {
         let paths_to_watch = {
-            let mut trie = ConsolidatingPathTrie::new(true);
+            let mut trie = ConsolidatingPathTrie::new(true, self.max_fsevent_paths);
             for path in self.watches.keys() {
                 trie.insert(path.clone());
             }
@@ -695,11 +700,11 @@ unsafe fn callback_impl(
 impl Watcher for FsEventWatcher {
     /// Create a new watcher.
     #[tracing::instrument(level = "debug", skip(event_handler))]
-    #[expect(clippy::used_underscore_binding)]
-    fn new<F: EventHandler>(event_handler: F, _config: Config) -> Result<Self> {
-        Ok(Self::from_event_handler(Arc::new(Mutex::new(
-            event_handler,
-        ))))
+    fn new<F: EventHandler>(event_handler: F, config: Config) -> Result<Self> {
+        Ok(Self::from_event_handler(
+            Arc::new(Mutex::new(event_handler)),
+            config.max_fsevent_paths(),
+        ))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -181,7 +181,7 @@ mod data {
             self.next.clear();
             self.is_stale = true;
 
-            let mut trie = ConsolidatingPathTrie::new(false);
+            let mut trie = ConsolidatingPathTrie::new(false, 0);
             for (path, mode) in watches {
                 if mode.recursive_mode == crate::RecursiveMode::Recursive {
                     trie.insert(path);


### PR DESCRIPTION
On macOS, the default file descriptor soft limit is 256. When watching many individual paths via FSEvents, the process can run out of file descriptors, causing `spawn EBADF` errors when spawning child processes.

This PR adds a `max_fsevent_paths` option (default 128) to `ConsolidatingPathTrie`. When the number of watched paths exceeds this limit, the trie automatically consolidates bottom-up — replacing the deepest individual paths with their parent directories — until the count is under the limit. Distinct subtrees are never merged (e.g. `/a/...` and `/b/...` won't consolidate to `/`).

Event routing is unaffected and the callback already filters against the original watch set.

```rust
// Default: 128 (stays under macOS default fd limit of 256)
Config::default()

// Custom limit
Config::default().with_max_fsevent_paths(512)

// Disable consolidation
Config::default().with_max_fsevent_paths(0)
```