### PR TITLE
perf: consolidate watch paths via `ConsolidatingPathTrie` on Windows

### DIFF
--- a/notify/benches/paths_mut_bench.rs
+++ b/notify/benches/paths_mut_bench.rs
@@ -40,6 +40,17 @@ fn create_temp_files(dir: &std::path::Path, count: usize) -> Vec<PathBuf> {
     paths
 }
 
+/// Helper function to create N sibling subdirectories under a shared parent
+fn create_sibling_subdirs(dir: &std::path::Path, count: usize) -> Vec<PathBuf> {
+    let mut paths = Vec::with_capacity(count);
+    for i in 0..count {
+        let sub = dir.join(format!("c{i:04}"));
+        std::fs::create_dir(&sub).expect("Failed to create subdirectory");
+        paths.push(sub);
+    }
+    paths
+}
+
 /// Benchmark helper: measures paths_mut total time (add all paths + commit)
 fn bench_paths_mut<W: Watcher>(watcher: &mut W, paths: &[PathBuf], mode: RecursiveMode) {
     let mut paths_mut = watcher.paths_mut();
@@ -64,7 +75,7 @@ fn bench_inotify_paths_mut(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("inotify_paths_mut");
 
-    for file_count in [100, 500, 1000] {
+    for file_count in [100, 200, 400] {
         for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
             let mode_str = match mode {
                 RecursiveMode::Recursive => "recursive",
@@ -95,6 +106,38 @@ fn bench_inotify_paths_mut(c: &mut Criterion) {
     group.finish();
 }
 
+// INotify sibling-subdir benchmarks (Linux/Android)
+#[cfg(target_os = "linux")]
+fn bench_inotify_sibling_subdirs(c: &mut Criterion) {
+    use notify::INotifyWatcher;
+
+    let mut group = c.benchmark_group("inotify_sibling_subdirs");
+
+    for count in [10, 100, 300] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(BenchmarkId::new(mode_str, count), &count, |b, &count| {
+                let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                let paths = create_sibling_subdirs(temp_dir.path(), count);
+
+                b.iter(|| {
+                    let mut watcher =
+                        INotifyWatcher::new(move |_res| {}, notify::Config::default())
+                            .expect("Failed to create watcher");
+
+                    bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 // FSEvent benchmarks (macOS)
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
 fn bench_fsevent_paths_mut(c: &mut Criterion) {
@@ -102,7 +145,7 @@ fn bench_fsevent_paths_mut(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("fsevent_paths_mut");
 
-    for file_count in [100, 500, 1000] {
+    for file_count in [100, 200, 400] {
         for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
             let mode_str = match mode {
                 RecursiveMode::Recursive => "recursive",
@@ -131,6 +174,38 @@ fn bench_fsevent_paths_mut(c: &mut Criterion) {
     group.finish();
 }
 
+// FSEvent sibling-subdir benchmarks (macOS)
+#[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
+fn bench_fsevent_sibling_subdirs(c: &mut Criterion) {
+    use notify::FsEventWatcher;
+
+    let mut group = c.benchmark_group("fsevent_sibling_subdirs");
+
+    for count in [10, 100, 300] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(BenchmarkId::new(mode_str, count), &count, |b, &count| {
+                let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                let paths = create_sibling_subdirs(temp_dir.path(), count);
+
+                b.iter(|| {
+                    let mut watcher =
+                        FsEventWatcher::new(move |_res| {}, notify::Config::default())
+                            .expect("Failed to create watcher");
+
+                    bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 // Kqueue benchmarks (macOS with macos_kqueue feature, BSD, iOS)
 #[cfg(any(
     all(target_os = "macos", feature = "macos_kqueue"),
@@ -145,7 +220,7 @@ fn bench_kqueue_paths_mut(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("kqueue_paths_mut");
 
-    for file_count in [100, 500, 1000] {
+    for file_count in [100, 200, 400] {
         for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
             let mode_str = match mode {
                 RecursiveMode::Recursive => "recursive",
@@ -174,6 +249,44 @@ fn bench_kqueue_paths_mut(c: &mut Criterion) {
     group.finish();
 }
 
+// Kqueue sibling-subdir benchmarks (macOS with macos_kqueue feature, BSD, iOS)
+#[cfg(any(
+    all(target_os = "macos", feature = "macos_kqueue"),
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+    target_os = "ios"
+))]
+fn bench_kqueue_sibling_subdirs(c: &mut Criterion) {
+    use notify::KqueueWatcher;
+
+    let mut group = c.benchmark_group("kqueue_sibling_subdirs");
+
+    for count in [10, 100, 300] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(BenchmarkId::new(mode_str, count), &count, |b, &count| {
+                let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                let paths = create_sibling_subdirs(temp_dir.path(), count);
+
+                b.iter(|| {
+                    let mut watcher = KqueueWatcher::new(move |_res| {}, notify::Config::default())
+                        .expect("Failed to create watcher");
+
+                    bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 // Windows benchmarks
 #[cfg(target_os = "windows")]
 fn bench_windows_paths_mut(c: &mut Criterion) {
@@ -181,7 +294,7 @@ fn bench_windows_paths_mut(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("windows_paths_mut");
 
-    for file_count in [100, 500, 1000] {
+    for file_count in [100, 200, 400] {
         for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
             let mode_str = match mode {
                 RecursiveMode::Recursive => "recursive",
@@ -212,27 +325,14 @@ fn bench_windows_paths_mut(c: &mut Criterion) {
     group.finish();
 }
 
-/// Workload matching the issue #62 motivating shape: many sibling subdirectory
-/// watches under a shared parent, none of them on the parent itself. This is
-/// what the `ConsolidatingPathTrie` is designed to optimize.
-#[cfg(target_os = "windows")]
-fn create_sibling_subdirs(dir: &std::path::Path, count: usize) -> Vec<PathBuf> {
-    let mut paths = Vec::with_capacity(count);
-    for i in 0..count {
-        let sub = dir.join(format!("c{i:04}"));
-        std::fs::create_dir(&sub).expect("Failed to create subdirectory");
-        paths.push(sub);
-    }
-    paths
-}
-
+// Windows sibling-subdir benchmarks
 #[cfg(target_os = "windows")]
 fn bench_windows_sibling_subdirs(c: &mut Criterion) {
     use notify::ReadDirectoryChangesWatcher;
 
     let mut group = c.benchmark_group("windows_sibling_subdirs");
 
-    for count in [10, 50, 100, 500] {
+    for count in [10, 100, 300] {
         for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
             let mode_str = match mode {
                 RecursiveMode::Recursive => "recursive",
@@ -263,7 +363,7 @@ fn bench_poll_paths_mut(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("poll_paths_mut");
 
-    for file_count in [100, 500, 1000] {
+    for file_count in [100, 200, 400] {
         for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
             let mode_str = match mode {
                 RecursiveMode::Recursive => "recursive",
@@ -292,19 +392,67 @@ fn bench_poll_paths_mut(c: &mut Criterion) {
     group.finish();
 }
 
+// Poll sibling-subdir benchmarks (cross-platform)
+fn bench_poll_sibling_subdirs(c: &mut Criterion) {
+    use notify::PollWatcher;
+
+    let mut group = c.benchmark_group("poll_sibling_subdirs");
+
+    for count in [10, 100, 300] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(BenchmarkId::new(mode_str, count), &count, |b, &count| {
+                let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                let paths = create_sibling_subdirs(temp_dir.path(), count);
+
+                b.iter(|| {
+                    let mut watcher = PollWatcher::new(move |_res| {}, notify::Config::default())
+                        .expect("Failed to create watcher");
+
+                    bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 // Configure criterion groups based on platform
 #[cfg(target_os = "linux")]
-criterion_group!(benches, bench_inotify_paths_mut, bench_poll_paths_mut);
+criterion_group!(
+    benches,
+    bench_inotify_paths_mut,
+    bench_inotify_sibling_subdirs,
+    bench_poll_paths_mut,
+    bench_poll_sibling_subdirs
+);
 
 #[cfg(all(
     target_os = "macos",
     feature = "macos_fsevent",
     not(feature = "macos_kqueue")
 ))]
-criterion_group!(benches, bench_fsevent_paths_mut, bench_poll_paths_mut);
+criterion_group!(
+    benches,
+    bench_fsevent_paths_mut,
+    bench_fsevent_sibling_subdirs,
+    bench_poll_paths_mut,
+    bench_poll_sibling_subdirs
+);
 
 #[cfg(all(target_os = "macos", feature = "macos_kqueue"))]
-criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
+criterion_group!(
+    benches,
+    bench_kqueue_paths_mut,
+    bench_kqueue_sibling_subdirs,
+    bench_poll_paths_mut,
+    bench_poll_sibling_subdirs
+);
 
 #[cfg(any(
     target_os = "freebsd",
@@ -313,14 +461,21 @@ criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
     target_os = "dragonfly",
     target_os = "ios"
 ))]
-criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
+criterion_group!(
+    benches,
+    bench_kqueue_paths_mut,
+    bench_kqueue_sibling_subdirs,
+    bench_poll_paths_mut,
+    bench_poll_sibling_subdirs
+);
 
 #[cfg(target_os = "windows")]
 criterion_group!(
     benches,
     bench_windows_paths_mut,
     bench_windows_sibling_subdirs,
-    bench_poll_paths_mut
+    bench_poll_paths_mut,
+    bench_poll_sibling_subdirs
 );
 
 #[cfg(not(any(
@@ -333,6 +488,6 @@ criterion_group!(
     target_os = "dragonfly",
     target_os = "ios"
 )))]
-criterion_group!(benches, bench_poll_paths_mut);
+criterion_group!(benches, bench_poll_paths_mut, bench_poll_sibling_subdirs);
 
 criterion_main!(benches);

--- a/notify/benches/paths_mut_bench.rs
+++ b/notify/benches/paths_mut_bench.rs
@@ -212,6 +212,51 @@ fn bench_windows_paths_mut(c: &mut Criterion) {
     group.finish();
 }
 
+/// Workload matching the issue #62 motivating shape: many sibling subdirectory
+/// watches under a shared parent, none of them on the parent itself. This is
+/// what the `ConsolidatingPathTrie` is designed to optimize.
+#[cfg(target_os = "windows")]
+fn create_sibling_subdirs(dir: &std::path::Path, count: usize) -> Vec<PathBuf> {
+    let mut paths = Vec::with_capacity(count);
+    for i in 0..count {
+        let sub = dir.join(format!("c{i:04}"));
+        std::fs::create_dir(&sub).expect("Failed to create subdirectory");
+        paths.push(sub);
+    }
+    paths
+}
+
+#[cfg(target_os = "windows")]
+fn bench_windows_sibling_subdirs(c: &mut Criterion) {
+    use notify::ReadDirectoryChangesWatcher;
+
+    let mut group = c.benchmark_group("windows_sibling_subdirs");
+
+    for count in [10, 50, 100, 500] {
+        for mode in [RecursiveMode::NonRecursive, RecursiveMode::Recursive] {
+            let mode_str = match mode {
+                RecursiveMode::Recursive => "recursive",
+                RecursiveMode::NonRecursive => "nonrecursive",
+            };
+
+            group.bench_with_input(BenchmarkId::new(mode_str, count), &count, |b, &count| {
+                let temp_dir = TempDir::new().expect("Failed to create temp dir");
+                let paths = create_sibling_subdirs(temp_dir.path(), count);
+
+                b.iter(|| {
+                    let mut watcher =
+                        ReadDirectoryChangesWatcher::new(move |_res| {}, notify::Config::default())
+                            .expect("Failed to create watcher");
+
+                    bench_paths_mut(&mut watcher, black_box(&paths), mode);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 // Poll benchmarks (cross-platform)
 fn bench_poll_paths_mut(c: &mut Criterion) {
     use notify::PollWatcher;
@@ -271,7 +316,12 @@ criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
 criterion_group!(benches, bench_kqueue_paths_mut, bench_poll_paths_mut);
 
 #[cfg(target_os = "windows")]
-criterion_group!(benches, bench_windows_paths_mut, bench_poll_paths_mut);
+criterion_group!(
+    benches,
+    bench_windows_paths_mut,
+    bench_windows_sibling_subdirs,
+    bench_poll_paths_mut
+);
 
 #[cfg(not(any(
     target_os = "linux",

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -288,17 +288,24 @@ impl ReadDirectoryChangesServer {
     }
 
     fn apply_staged(&mut self, staged: Vec<StagedChange>) -> Result<()> {
+        // Pass 1: run consolidation lexically on each staged path's direct
+        // parent dir (no metadata yet). Open that consolidated set so every
+        // staged path has *some* covering watch installed before its
+        // metadata is read. This collapses what would otherwise be N
+        // per-path pre-opens into a single consolidated open, avoiding the
+        // close-and-reopen cycle that the previous flow paid when
+        // consolidation later merged the per-path pre-opens away.
+        self.pre_open_consolidated(&staged)?;
+
+        // Pass 2: resolve metadata for each staged Add now that watches are
+        // armed, and apply Removes.
         let mut first_error: Option<Error> = None;
         for change in staged {
             let res = match change {
                 StagedChange::Add(path, mode) => {
                     let merged = self.merge_user_watch_mode(&path, mode);
-                    // Pre-open `tracked_parent` before metadata to avoid the
-                    // Windows quirk documented on `add_watch`.
-                    self.pre_open_tracked_parent(&path, merged).and_then(|()| {
-                        resolve_user_watch(&path, merged).map(|uw| {
-                            self.watches.borrow_mut().insert(path, uw);
-                        })
+                    resolve_user_watch(&path, merged).map(|uw| {
+                        self.watches.borrow_mut().insert(path, uw);
                     })
                 }
                 StagedChange::Remove(path) => {
@@ -312,8 +319,10 @@ impl ReadDirectoryChangesServer {
                 first_error = Some(e);
             }
         }
-        // Even if some staged changes failed to resolve, apply the successful ones
-        // so the watcher state remains consistent with `self.watches`.
+        // Pass 3: final rebuild against the actual primaries. The
+        // conservatively-opened handles from pass 1 are either left in place
+        // (when they coincide with the final target) or rewritten by the
+        // normal diff in `rebuild_watch_handles`.
         if let Err(e) = self.rebuild_watch_handles()
             && first_error.is_none()
         {
@@ -323,6 +332,41 @@ impl ReadDirectoryChangesServer {
             Some(e) => Err(e),
             None => Ok(()),
         }
+    }
+
+    /// Phase 1 of the batched commit: open a single consolidated set of
+    /// "direct parent" dirs that lexically cover every TrackPath staged
+    /// Add. This satisfies the Windows metadata quirk (parent must be
+    /// watched before `path.metadata()`) in a way that doesn't waste opens
+    /// when consolidation later collapses everything into a higher
+    /// ancestor.
+    ///
+    /// The recursive flag for each conservative target is `true` whenever
+    /// some staged path's direct parent is a strict descendant of that
+    /// target (i.e., consolidation collapsed it from below). Otherwise
+    /// non-recursive — matching the per-call `pre_open_tracked_parent`.
+    fn pre_open_consolidated(&mut self, staged: &[StagedChange]) -> Result<()> {
+        let mut trie = ConsolidatingPathTrie::new(true, 0);
+        let mut staged_parents: Vec<PathBuf> = Vec::new();
+        for change in staged {
+            if let StagedChange::Add(path, mode) = change
+                && mode.target_mode == TargetMode::TrackPath
+                && let Some(parent) = path.parent()
+            {
+                trie.insert(parent);
+                staged_parents.push(parent.to_path_buf());
+            }
+        }
+        for target in trie.values() {
+            if self.watch_handles.contains_key(&target) {
+                continue;
+            }
+            let recursive = staged_parents
+                .iter()
+                .any(|p| p != &target && p.starts_with(&target));
+            self.add_watch_raw(target, recursive, false)?;
+        }
+        Ok(())
     }
 
     /// Build the desired set of OS-level dirs from `self.watches`, run consolidation

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -78,21 +78,15 @@ fn normalize_path_separators(path: PathBuf) -> PathBuf {
 }
 
 /// The resolved OS-level coverage for a user watch request.
-///
-/// `primary` is the directory we'd open with `CreateFileW` to receive content
-/// events for this watch, plus whether the user asked for a recursive subtree.
-/// `tracked_parent` is an optional extra directory whose direct children
-/// include `primary` (or the user path itself, for a nonexistent path in
-/// [`TargetMode::TrackPath`]); its watch lets us detect rename or delete
-/// events for the watched path itself.
-///
-/// This is kept separate from `watches`, which stores only the user's raw
-/// [`WatchMode`] request. Resolution needs a `metadata()` call, so it is cached
-/// here instead of being recomputed on every rebuild.
 #[derive(Debug, Clone)]
 struct ResolvedWatch {
+    /// The directory we'd open with `CreateFileW` to receive content events
+    /// for this watch, plus whether the user asked for a recursive subtree.
     primary: Option<(PathBuf, bool)>,
-    tracked_parent: Option<PathBuf>,
+    /// Whether the watch also needs an auxiliary watch on the user path's
+    /// direct parent so we can detect rename or delete events for the watched
+    /// path itself.
+    needs_tracked_parent: bool,
 }
 
 #[derive(Clone)]
@@ -250,78 +244,41 @@ impl ReadDirectoryChangesServer {
 
     #[tracing::instrument(level = "trace", skip(self))]
     fn add_watch(&mut self, path: PathBuf, watch_mode: WatchMode) -> Result<PathBuf> {
-        let merged_mode = self.merge_user_watch_mode(&path, watch_mode);
-        // On Windows, reading metadata on a directory *before* its parent dir
-        // has a `ReadDirectoryChangesW` watch active causes the parent watch
-        // to silently miss any future `FILE_ACTION_MODIFIED` event for that
-        // dir (the metadata call appears to "consume" the dir's modification
-        // slot). To preserve event delivery, pre-open the tracked-parent
-        // watch before resolving metadata, matching the order the previous
-        // per-call code used.
-        self.pre_open_tracked_parent(&path, merged_mode)?;
-        let resolved = resolve_user_watch(&path, merged_mode)?;
-        self.watches.borrow_mut().insert(path.clone(), merged_mode);
-        self.resolved_watches.insert(path.clone(), resolved);
+        self.add_watch_internal(path.clone(), watch_mode)?;
         self.rebuild_watch_handles()?;
         Ok(path)
     }
 
-    /// Open a non-recursive watch on `path.parent()` if `mode` is in
-    /// [`TargetMode::TrackPath`] and no handle exists yet. The only input
-    /// needed is the user path itself, so this can run before any metadata
-    /// resolution and is safe to use to avoid the Windows quirk described in
-    /// [`add_watch`].
-    fn pre_open_tracked_parent(&mut self, path: &Path, mode: WatchMode) -> Result<()> {
-        if mode.target_mode != TargetMode::TrackPath {
-            return Ok(());
-        }
-        let Some(parent) = path.parent() else {
-            return Ok(());
-        };
-        if self.watch_handles.contains_key(parent) {
-            return Ok(());
-        }
-        self.add_watch_raw(parent.to_path_buf(), false, false)
-    }
-
-    /// Merge an incoming watch_mode with any existing entry for `path`, so that
-    /// repeated calls to watch the same path only ever upgrade coverage.
-    fn merge_user_watch_mode(&self, path: &Path, watch_mode: WatchMode) -> WatchMode {
-        match self.watches.borrow().get(path) {
+    /// Register a single user watch: merge `mode` with any existing entry for
+    /// `path` (so repeated watches of the same path only ever upgrade
+    /// coverage), resolve it, and record both the raw request in `watches` and
+    /// the resolved coverage in `resolved_watches`.
+    ///
+    /// Watch handles are left untouched; the caller drives `rebuild_watch_handles`.
+    fn add_watch_internal(&mut self, path: PathBuf, mode: WatchMode) -> Result<()> {
+        let merged = match self.watches.borrow().get(&path) {
             Some(existing) => {
                 let mut merged = *existing;
-                merged.upgrade_with(watch_mode);
+                merged.upgrade_with(mode);
                 merged
             }
-            None => watch_mode,
-        }
+            None => mode,
+        };
+        let resolved = resolve_user_watch(&path, merged)?;
+        self.watches.borrow_mut().insert(path.clone(), merged);
+        self.resolved_watches.insert(path, resolved);
+        Ok(())
     }
 
     fn apply_staged(&mut self, staged: Vec<StagedChange>) -> Result<()> {
-        // Pass 1: run consolidation lexically on each staged path's direct
-        // parent dir (no metadata yet). Open that consolidated set so every
-        // staged path has *some* covering watch installed before its
-        // metadata is read. This collapses what would otherwise be N
-        // per-path pre-opens into a single consolidated open, avoiding the
-        // close-and-reopen cycle that the previous flow paid when
-        // consolidation later merged the per-path pre-opens away.
-        self.pre_open_consolidated(&staged)?;
-
-        // Pass 2: resolve metadata for each staged Add now that watches are
-        // armed, and apply Removes.
+        // Apply every staged change to `watches` / `resolved_watches`, then
+        // converge the OS handles with a single rebuild.
         let mut first_error: Option<Error> = None;
         for change in staged {
             let res = match change {
-                StagedChange::Add(path, mode) => {
-                    let merged = self.merge_user_watch_mode(&path, mode);
-                    resolve_user_watch(&path, merged).map(|resolved| {
-                        self.watches.borrow_mut().insert(path.clone(), merged);
-                        self.resolved_watches.insert(path, resolved);
-                    })
-                }
+                StagedChange::Add(path, mode) => self.add_watch_internal(path, mode),
                 StagedChange::Remove(path) => {
-                    self.watches.borrow_mut().remove(&path);
-                    self.resolved_watches.remove(&path);
+                    self.remove_watch_internal(&path);
                     Ok(())
                 }
             };
@@ -331,10 +288,6 @@ impl ReadDirectoryChangesServer {
                 first_error = Some(e);
             }
         }
-        // Pass 3: final rebuild against the actual primaries. The
-        // conservatively-opened handles from pass 1 are either left in place
-        // (when they coincide with the final target) or rewritten by the
-        // normal diff in `rebuild_watch_handles`.
         if let Err(e) = self.rebuild_watch_handles()
             && first_error.is_none()
         {
@@ -346,46 +299,11 @@ impl ReadDirectoryChangesServer {
         }
     }
 
-    /// Phase 1 of the batched commit: open a single consolidated set of
-    /// "direct parent" dirs that lexically cover every TrackPath staged
-    /// Add. This satisfies the Windows metadata quirk (parent must be
-    /// watched before `path.metadata()`) in a way that doesn't waste opens
-    /// when consolidation later collapses everything into a higher
-    /// ancestor.
-    ///
-    /// The recursive flag for each conservative target is `true` whenever
-    /// some staged path's direct parent is a strict descendant of that
-    /// target (i.e., consolidation collapsed it from below). Otherwise
-    /// non-recursive — matching the per-call `pre_open_tracked_parent`.
-    fn pre_open_consolidated(&mut self, staged: &[StagedChange]) -> Result<()> {
-        let mut trie = ConsolidatingPathTrie::new(true, 0);
-        let mut staged_parents: Vec<PathBuf> = Vec::new();
-        for change in staged {
-            if let StagedChange::Add(path, mode) = change
-                && mode.target_mode == TargetMode::TrackPath
-                && let Some(parent) = path.parent()
-            {
-                trie.insert(parent);
-                staged_parents.push(parent.to_path_buf());
-            }
-        }
-        for target in trie.values() {
-            if self.watch_handles.contains_key(&target) {
-                continue;
-            }
-            let recursive = staged_parents
-                .iter()
-                .any(|p| p != &target && p.starts_with(&target));
-            self.add_watch_raw(target, recursive, false)?;
-        }
-        Ok(())
-    }
-
     /// Build the desired set of OS-level dirs from `self.resolved_watches`, run
-    /// consolidation over the *primary* dir requests, and then layer in any
-    /// [`ResolvedWatch::tracked_parent`] entries as auxiliary non-recursive
-    /// watches if they aren't already covered. Finally diff against
-    /// `self.watch_handles` to converge open handles.
+    /// consolidation over the *primary* dir requests, and then layer in a
+    /// [`ResolvedWatch::needs_tracked_parent`] watch on each user path's parent
+    /// as an auxiliary non-recursive watch if it isn't already covered. Finally
+    /// diff against `self.watch_handles` to converge open handles.
     ///
     /// `tracked_parent` is deliberately kept outside the consolidation trie:
     /// merging it with the primary would force the primary watch up to the parent
@@ -420,15 +338,17 @@ impl ReadDirectoryChangesServer {
             })
             .collect();
 
-        // 3. Layer in tracked_parent entries. If the parent already appears in
-        //    `target` (whether as a consolidated parent or a directly requested
-        //    primary), the existing entry is sufficient for rename detection on
-        //    direct children. Otherwise add it as a non-recursive auxiliary watch.
-        for resolved in self.resolved_watches.values() {
-            if let Some(parent) = &resolved.tracked_parent
+        // 3. Layer in tracked-parent entries. A watch that needs one gets an
+        //    auxiliary non-recursive watch on its direct parent. If the parent
+        //    already appears in `target` (whether as a consolidated parent or a
+        //    directly requested primary), the existing entry is sufficient for
+        //    rename detection on direct children.
+        for (path, resolved) in &self.resolved_watches {
+            if resolved.needs_tracked_parent
+                && let Some(parent) = path.parent()
                 && !target.contains_key(parent)
             {
-                target.insert(parent.clone(), false);
+                target.insert(parent.to_path_buf(), false);
             }
         }
 
@@ -549,11 +469,18 @@ impl ReadDirectoryChangesServer {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
-    fn remove_watch(&mut self, path: &Path) {
+    /// Remove a single user watch from `watches` and `resolved_watches`,
+    /// returning whether an entry was present. Watch handles are left
+    /// untouched; the caller drives `rebuild_watch_handles`.
+    fn remove_watch_internal(&mut self, path: &Path) -> bool {
         let removed = self.watches.borrow_mut().remove(path).is_some();
         self.resolved_watches.remove(path);
-        if removed
+        removed
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn remove_watch(&mut self, path: &Path) {
+        if self.remove_watch_internal(path)
             && let Err(e) = self.rebuild_watch_handles()
         {
             tracing::error!(?e, "failed to rebuild watch handles after remove_watch");
@@ -581,18 +508,15 @@ impl ReadDirectoryChangesServer {
 /// which OS-level directories we'd want to watch. Mirrors the metadata + parent
 /// logic that the old per-call `add_watch` used to inline.
 fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
-    let tracked_parent_for_dir = if mode.target_mode == TargetMode::TrackPath {
-        path.parent().map(Path::to_path_buf)
-    } else {
-        None
-    };
+    let is_track_path = mode.target_mode == TargetMode::TrackPath;
 
+    // Note: reading metadata on a directory triggers a modify event
     match path.metadata().map_err(Error::io_watch) {
         Ok(meta) => {
             if meta.is_dir() {
                 Ok(ResolvedWatch {
                     primary: Some((path.to_path_buf(), mode.recursive_mode.is_recursive())),
-                    tracked_parent: tracked_parent_for_dir,
+                    needs_tracked_parent: is_track_path,
                 })
             } else if meta.is_file() {
                 let parent = path.parent().unwrap_or(path).to_path_buf();
@@ -601,7 +525,7 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
                     // so the "tracked parent" rename-detection requirement is
                     // already covered by `primary`; no separate entry needed.
                     primary: Some((parent, mode.recursive_mode.is_recursive())),
-                    tracked_parent: None,
+                    needs_tracked_parent: false,
                 })
             } else {
                 Err(
@@ -613,12 +537,10 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
         Err(err) => {
             // For TrackPath we keep the watch alive and rely on the parent dir
             // to tell us when something appears at `path`.
-            if mode.target_mode == TargetMode::TrackPath
-                && matches!(err.kind, ErrorKind::PathNotFound)
-            {
+            if is_track_path && matches!(err.kind, ErrorKind::PathNotFound) {
                 Ok(ResolvedWatch {
                     primary: None,
-                    tracked_parent: tracked_parent_for_dir,
+                    needs_tracked_parent: true,
                 })
             } else {
                 Err(err)
@@ -1028,7 +950,7 @@ impl ReadDirectoryChangesWatcher {
 ///
 /// `add` and `remove` only stage the change in a local `Vec`; nothing crosses
 /// the channel until `commit`, at which point the server applies the staged
-/// changes in order and runs consolidation **once**. On error the first error
+/// changes in order and runs consolidation once. On error the first error
 /// is propagated and the remaining staged operations are skipped at staging
 /// time, but any operations that did make it into `self.watches` before the
 /// failure remain applied.
@@ -1316,11 +1238,8 @@ pub mod tests {
         watcher.watch_recursively(&tmpdir);
         std::fs::write(&path, b"123").expect("write");
 
-        rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
-            expected(&path).modify_any().multiple(),
-        ])
-        .ensure_no_tail();
+        rx.wait_ordered_exact([expected(&path).modify_any().multiple()])
+            .ensure_no_tail();
         assert_eq!(
             watcher.get_watch_handles(),
             HashSet::from([tmpdir.parent_path_buf(), tmpdir.to_path_buf()])
@@ -1340,11 +1259,8 @@ pub mod tests {
         watcher.watch_recursively(&tmpdir);
         file.set_permissions(permissions).expect("set_permissions");
 
-        rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
-            expected(&path).modify_any(),
-        ])
-        .ensure_no_tail();
+        rx.wait_ordered_exact([expected(&path).modify_any()])
+            .ensure_no_tail();
         assert_eq!(
             watcher.get_watch_handles(),
             HashSet::from([tmpdir.parent_path_buf(), tmpdir.to_path_buf()])
@@ -1365,7 +1281,6 @@ pub mod tests {
         std::fs::rename(&path, &new_path).expect("rename");
 
         rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
             expected(&path).rename_from(),
             expected(&new_path).rename_to(),
             expected(tmpdir.path()).modify_any(),
@@ -1461,11 +1376,8 @@ pub mod tests {
 
         std::fs::remove_file(&file).expect("remove");
 
-        rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
-            expected(&file).remove_any(),
-        ])
-        .ensure_no_tail();
+        rx.wait_ordered_exact([expected(&file).remove_any()])
+            .ensure_no_tail();
         assert_eq!(
             watcher.get_watch_handles(),
             HashSet::from([tmpdir.parent_path_buf(), tmpdir.to_path_buf()])
@@ -1539,7 +1451,6 @@ pub mod tests {
         std::fs::rename(&overwriting_file, &overwritten_file).expect("rename");
 
         rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
             expected(&overwriting_file).create_any(),
             expected(tmpdir.path()).modify_any(),
             expected(&overwriting_file).modify_any().multiple(),
@@ -1639,11 +1550,8 @@ pub mod tests {
         watcher.watch_recursively(&tmpdir);
         std::fs::set_permissions(&path, permissions).expect("set_permissions");
 
-        rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
-            expected(&path).modify_any(),
-        ])
-        .ensure_no_tail();
+        rx.wait_ordered_exact([expected(&path).modify_any()])
+            .ensure_no_tail();
         assert_eq!(
             watcher.get_watch_handles(),
             HashSet::from([tmpdir.parent_path_buf(), tmpdir.to_path_buf()])
@@ -1664,7 +1572,6 @@ pub mod tests {
         std::fs::rename(&path, &new_path).expect("rename");
 
         rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
             expected(&path).rename_from(),
             expected(&new_path).rename_to(),
             expected(tmpdir.path()).modify_any(),
@@ -1687,11 +1594,8 @@ pub mod tests {
         watcher.watch_recursively(&tmpdir);
         std::fs::remove_dir(&path).expect("remove");
 
-        rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
-            expected(&path).remove_any(),
-        ])
-        .ensure_no_tail();
+        rx.wait_ordered_exact([expected(&path).remove_any()])
+            .ensure_no_tail();
         assert_eq!(
             watcher.get_watch_handles(),
             HashSet::from([tmpdir.parent_path_buf(), tmpdir.to_path_buf()])
@@ -1770,7 +1674,6 @@ pub mod tests {
         std::fs::rename(&new_path, &new_path2).expect("rename2");
 
         rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
             expected(&path).rename_from(),
             expected(&new_path).rename_to(),
             expected(tmpdir.path()).modify_any(),
@@ -1800,7 +1703,7 @@ pub mod tests {
 
         std::fs::rename(&path, &new_path).expect("rename");
 
-        rx.wait_ordered_exact([expected(&subdir).modify_any(), expected(path).remove_any()])
+        rx.wait_ordered_exact([expected(path).remove_any()])
             .ensure_no_tail();
         assert_eq!(
             watcher.get_watch_handles(),
@@ -1826,7 +1729,6 @@ pub mod tests {
         std::fs::remove_file(&new_path).expect("remove");
 
         rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
             expected(&file1).create_any(),
             expected(&file1).modify_any().multiple(),
             expected(tmpdir.path()).modify_any(),
@@ -1859,7 +1761,6 @@ pub mod tests {
         std::fs::rename(&new_path1, &new_path2).expect("rename2");
 
         rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
             expected(&path).rename_from(),
             expected(&new_path1).rename_to(),
             expected(tmpdir.path()).modify_any(),
@@ -1891,11 +1792,8 @@ pub mod tests {
         )
         .expect("set_time");
 
-        rx.wait_ordered_exact([
-            expected(tmpdir.path()).modify_any(),
-            expected(&path).modify_any(),
-        ])
-        .ensure_no_tail();
+        rx.wait_ordered_exact([expected(&path).modify_any()])
+            .ensure_no_tail();
     }
 
     #[test]
@@ -1991,9 +1889,6 @@ pub mod tests {
         watcher.watch_nonrecursively(&path);
         std::fs::File::create_new(&file).expect("create");
         std::fs::remove_file(&file).expect("delete");
-
-        rx.wait_ordered_exact([expected(&path).modify_any()])
-            .ensure_no_tail();
 
         watcher.watch_recursively(&path);
         std::fs::File::create_new(&file).expect("create");

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -5,11 +5,12 @@
 //!
 //! [ref]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363950(v=vs.85).aspx
 
+use crate::consolidating_path_trie::ConsolidatingPathTrie;
 use crate::{
     BoundSender, Config, ErrorKind, PathsMut, Receiver, Sender, TargetMode, WatchMode, bounded,
     unbounded,
 };
-use crate::{Error, EventHandler, RecursiveMode, Result, Watcher};
+use crate::{Error, EventHandler, Result, Watcher};
 use crate::{WatcherKind, event::*};
 use rustc_hash::FxBuildHasher;
 use std::alloc;
@@ -76,10 +77,25 @@ fn normalize_path_separators(path: PathBuf) -> PathBuf {
     PathBuf::from(OsString::from_wide(&encoded_path))
 }
 
+/// A user-registered watch request, paired with its resolved OS-level coverage.
+///
+/// `mode` preserves the user's intent. `primary` is the directory we'd open with
+/// `CreateFileW` to receive content events for this watch, plus whether the user
+/// asked for a recursive subtree. `tracked_parent` is an optional extra directory
+/// whose direct children include `primary` (or the user path itself, for
+/// nonexistent + [`TargetMode::TrackPath`]) — its watch lets us detect rename or
+/// delete events for the watched path itself.
+#[derive(Debug, Clone)]
+struct UserWatch {
+    mode: WatchMode,
+    primary: Option<(PathBuf, bool)>,
+    tracked_parent: Option<PathBuf>,
+}
+
 #[derive(Clone)]
 struct ReadData {
     dir: PathBuf, // directory that is being watched
-    watches: Rc<RefCell<HashMap<PathBuf, WatchMode, FxBuildHasher>>>,
+    watches: Rc<RefCell<HashMap<PathBuf, UserWatch, FxBuildHasher>>>,
     complete_sem: HANDLE,
     is_recursive: bool,
 }
@@ -129,7 +145,7 @@ struct ReadDirectoryChangesServer {
     rx: Receiver<Action>,
     event_handler: Arc<Mutex<dyn EventHandler>>,
     cmd_tx: Sender<Result<PathBuf>>,
-    watches: Rc<RefCell<HashMap<PathBuf, WatchMode, FxBuildHasher>>>,
+    watches: Rc<RefCell<HashMap<PathBuf, UserWatch, FxBuildHasher>>>,
     watch_handles: HashMap<PathBuf, (WatchState, /* is_recursive */ bool), FxBuildHasher>,
     wakeup_sem: HANDLE,
 }
@@ -225,84 +241,180 @@ impl ReadDirectoryChangesServer {
 
     #[tracing::instrument(level = "trace", skip(self))]
     fn add_watch(&mut self, path: PathBuf, watch_mode: WatchMode) -> Result<PathBuf> {
-        let existing_watch_mode = self.watches.borrow().get(&path).copied();
-        if let Some(existing) = existing_watch_mode {
-            let need_upgrade_to_recursive = match existing.recursive_mode {
-                RecursiveMode::Recursive => false,
-                RecursiveMode::NonRecursive => {
-                    watch_mode.recursive_mode == RecursiveMode::Recursive
+        let merged_mode = self.merge_user_watch_mode(&path, watch_mode);
+        // On Windows, reading metadata on a directory *before* its parent dir
+        // has a `ReadDirectoryChangesW` watch active causes the parent watch
+        // to silently miss any future `FILE_ACTION_MODIFIED` event for that
+        // dir (the metadata call appears to "consume" the dir's modification
+        // slot). To preserve event delivery, pre-open the tracked-parent
+        // watch before resolving metadata, matching the order the previous
+        // per-call code used.
+        self.pre_open_tracked_parent(&path, merged_mode)?;
+        let user_watch = resolve_user_watch(&path, merged_mode)?;
+        self.watches.borrow_mut().insert(path.clone(), user_watch);
+        self.rebuild_watch_handles()?;
+        Ok(path)
+    }
+
+    /// Open a non-recursive watch on `path.parent()` if `mode` is in
+    /// [`TargetMode::TrackPath`] and no handle exists yet. The only input
+    /// needed is the user path itself, so this can run before any metadata
+    /// resolution and is safe to use to avoid the Windows quirk described in
+    /// [`add_watch`].
+    fn pre_open_tracked_parent(&mut self, path: &Path, mode: WatchMode) -> Result<()> {
+        if mode.target_mode != TargetMode::TrackPath {
+            return Ok(());
+        }
+        let Some(parent) = path.parent() else {
+            return Ok(());
+        };
+        if self.watch_handles.contains_key(parent) {
+            return Ok(());
+        }
+        self.add_watch_raw(parent.to_path_buf(), false, false)
+    }
+
+    /// Merge an incoming watch_mode with any existing entry for `path`, so that
+    /// repeated calls to watch the same path only ever upgrade coverage.
+    fn merge_user_watch_mode(&self, path: &Path, watch_mode: WatchMode) -> WatchMode {
+        match self.watches.borrow().get(path) {
+            Some(existing) => {
+                let mut merged = existing.mode;
+                merged.upgrade_with(watch_mode);
+                merged
+            }
+            None => watch_mode,
+        }
+    }
+
+    fn apply_staged(&mut self, staged: Vec<StagedChange>) -> Result<()> {
+        let mut first_error: Option<Error> = None;
+        for change in staged {
+            let res = match change {
+                StagedChange::Add(path, mode) => {
+                    let merged = self.merge_user_watch_mode(&path, mode);
+                    // Pre-open `tracked_parent` before metadata to avoid the
+                    // Windows quirk documented on `add_watch`.
+                    self.pre_open_tracked_parent(&path, merged).and_then(|()| {
+                        resolve_user_watch(&path, merged).map(|uw| {
+                            self.watches.borrow_mut().insert(path, uw);
+                        })
+                    })
+                }
+                StagedChange::Remove(path) => {
+                    self.watches.borrow_mut().remove(&path);
+                    Ok(())
                 }
             };
-            let need_to_watch_parent_newly = match existing.target_mode {
-                TargetMode::TrackPath => false,
-                TargetMode::NoTrack => watch_mode.target_mode == TargetMode::TrackPath,
-            };
-            tracing::trace!(
-                ?need_upgrade_to_recursive,
-                ?need_to_watch_parent_newly,
-                "upgrading existing watch for path: {}",
-                path.display()
-            );
-            if need_to_watch_parent_newly && let Some(parent) = path.parent() {
-                self.add_watch_raw(parent.to_path_buf(), false, false)?;
+            if let Err(e) = res
+                && first_error.is_none()
+            {
+                first_error = Some(e);
             }
-            if !need_upgrade_to_recursive {
-                return Ok(path);
-            }
-        } else if watch_mode.target_mode == TargetMode::TrackPath
-            && let Some(parent) = path.parent()
+        }
+        // Even if some staged changes failed to resolve, apply the successful ones
+        // so the watcher state remains consistent with `self.watches`.
+        if let Err(e) = self.rebuild_watch_handles()
+            && first_error.is_none()
         {
-            self.add_watch_raw(parent.to_path_buf(), false, false)?;
+            first_error = Some(e);
+        }
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Build the desired set of OS-level dirs from `self.watches`, run consolidation
+    /// over the *primary* dir requests, and then layer in any [`UserWatch::tracked_parent`]
+    /// entries as auxiliary non-recursive watches if they aren't already covered.
+    /// Finally diff against `self.watch_handles` to converge open handles.
+    ///
+    /// `tracked_parent` is deliberately kept outside the consolidation trie:
+    /// merging it with the primary would force the primary watch up to the parent
+    /// and make it recursive, which floods the event filter with sibling events
+    /// that the user never asked about.
+    fn rebuild_watch_handles(&mut self) -> Result<()> {
+        // 1. Run consolidation over only the primary dir requests.
+        let mut trie = ConsolidatingPathTrie::new(true, 0);
+        {
+            let watches = self.watches.borrow();
+            for uw in watches.values() {
+                if let Some((dir, _)) = &uw.primary {
+                    trie.insert(dir);
+                }
+            }
+        }
+        let primary_paths = trie.values();
+
+        // 2. Compute desired recursive flag for each consolidated primary.
+        let mut target: HashMap<PathBuf, bool, FxBuildHasher> = {
+            let watches = self.watches.borrow();
+            primary_paths
+                .into_iter()
+                .map(|p| {
+                    let recursive = compute_recursive_flag(&p, &watches);
+                    (p, recursive)
+                })
+                .collect()
+        };
+
+        // 3. Layer in tracked_parent entries. If the parent already appears in
+        //    `target` (whether as a consolidated parent or a directly requested
+        //    primary), the existing entry is sufficient for rename detection on
+        //    direct children. Otherwise add it as a non-recursive auxiliary watch.
+        {
+            let watches = self.watches.borrow();
+            for uw in watches.values() {
+                if let Some(parent) = &uw.tracked_parent
+                    && !target.contains_key(parent)
+                {
+                    target.insert(parent.clone(), false);
+                }
+            }
         }
 
-        let metadata = match path.metadata().map_err(Error::io_watch) {
-            Ok(meta) => {
-                // path must be either a file or directory
-                if !meta.is_dir() && !meta.is_file() {
-                    return Err(Error::generic(
-                        "Input watch path is neither a file nor a directory.",
-                    )
-                    .add_path(path));
-                }
-                meta
+        // 4. Diff `target` against `self.watch_handles`. Close handles that
+        //    shouldn't exist, recreate those whose recursive flag changed, leave
+        //    matching handles untouched, and open any new ones.
+        let to_remove: Vec<PathBuf> = self
+            .watch_handles
+            .iter()
+            .filter(|(p, (_, is_rec))| target.get(*p).is_none_or(|t| t != is_rec))
+            .map(|(p, _)| p.clone())
+            .collect();
+        for p in to_remove {
+            if let Some((ws, _)) = self.watch_handles.remove(&p) {
+                stop_watch(&ws);
             }
-            Err(err) => {
-                if watch_mode.target_mode == TargetMode::TrackPath
-                    && matches!(err.kind, ErrorKind::PathNotFound)
-                {
-                    self.watches.borrow_mut().insert(path.clone(), watch_mode);
-                    return Ok(path);
-                }
-                return Err(err);
+        }
+
+        // Open new handles in a deterministic order: shallower paths first,
+        // ties broken lexically. This matches the previous per-call flow which
+        // opened the tracked-parent watch before the primary.
+        let mut to_open: Vec<(PathBuf, bool)> = target
+            .into_iter()
+            .filter(|(p, _)| !self.watch_handles.contains_key(p))
+            .collect();
+        to_open.sort_by(|(a, _), (b, _)| {
+            a.components()
+                .count()
+                .cmp(&b.components().count())
+                .then_with(|| a.cmp(b))
+        });
+
+        let mut first_error: Option<Error> = None;
+        for (path, is_recursive) in to_open {
+            if let Err(e) = self.add_watch_raw(path, is_recursive, false)
+                && first_error.is_none()
+            {
+                first_error = Some(e);
             }
-        };
-
-        let (watching_file, dir_target) = {
-            if metadata.is_dir() {
-                (false, path.clone())
-            } else {
-                // emulate file watching by watching the parent directory
-                (true, path.parent().unwrap().to_path_buf())
-            }
-        };
-
-        self.add_watch_raw(
-            dir_target,
-            watch_mode.recursive_mode.is_recursive(),
-            watching_file,
-        )?;
-
-        let upgraded_watch_mode = if let Some(mut existing) = existing_watch_mode {
-            existing.upgrade_with(watch_mode);
-            existing
-        } else {
-            watch_mode
-        };
-        self.watches
-            .borrow_mut()
-            .insert(path.clone(), upgraded_watch_mode);
-
-        Ok(path)
+        }
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
@@ -381,28 +493,20 @@ impl ReadDirectoryChangesServer {
 
     #[tracing::instrument(level = "trace", skip(self))]
     fn remove_watch(&mut self, path: &Path) {
-        if self.watches.borrow_mut().remove(path).is_some() {
-            self.remove_watch_raw(path);
+        if self.watches.borrow_mut().remove(path).is_some()
+            && let Err(e) = self.rebuild_watch_handles()
+        {
+            tracing::error!(?e, "failed to rebuild watch handles after remove_watch");
         }
     }
 
+    /// Drop a watch handle out-of-band when the OS reports that the directory is
+    /// gone (or some other error invalidated it). The handle entry is purged
+    /// without consulting `self.watches`, since the corresponding user watch
+    /// may still be present and will be re-opened on the next rebuild.
     #[tracing::instrument(level = "trace", skip(self))]
     fn remove_watch_raw(&mut self, path: &Path) {
         if let Some((ws, _)) = self.watch_handles.remove(path) {
-            stop_watch(&ws);
-        } else if let Some(parent_path) = path.parent()
-            && self.watches.borrow().get(parent_path).is_none()
-            && self
-                .watches
-                .borrow()
-                .keys()
-                .filter(|p| p.starts_with(parent_path))
-                .count()
-                == 0
-            && let Some((ws, _)) = self.watch_handles.remove(parent_path)
-        {
-            // if the parent path is not watched, the watch handle is used for the files under it
-            // if no files under it are watched anymore, we can stop the watch on the parent path
             stop_watch(&ws);
         }
     }
@@ -411,30 +515,102 @@ impl ReadDirectoryChangesServer {
         tx.send(Ok(false))
             .expect("configuration channel disconnect");
     }
+}
 
-    /// Apply a batch of staged changes from [`WindowsPathsMut::commit`] in
-    /// order. Each change reuses the existing per-call `add_watch` /
-    /// `remove_watch` paths; the only saving over the default `PathsMut` is
-    /// that the whole batch crosses the action channel as a single message
-    /// and is acked once instead of N times.
-    fn apply_staged(&mut self, staged: Vec<StagedChange>) -> Result<()> {
-        let mut first_error: Option<Error> = None;
-        for change in staged {
-            let res = match change {
-                StagedChange::Add(path, mode) => self.add_watch(path, mode).map(|_| ()),
-                StagedChange::Remove(path) => {
-                    self.remove_watch(&path);
-                    Ok(())
-                }
-            };
-            if let Err(e) = res
-                && first_error.is_none()
-            {
-                first_error = Some(e);
+/// Resolve a user-supplied watch path + mode into a [`UserWatch`] describing
+/// which OS-level directories we'd want to watch. Mirrors the metadata + parent
+/// logic that the old per-call `add_watch` used to inline.
+fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<UserWatch> {
+    let tracked_parent_for_dir = if mode.target_mode == TargetMode::TrackPath {
+        path.parent().map(Path::to_path_buf)
+    } else {
+        None
+    };
+
+    match path.metadata().map_err(Error::io_watch) {
+        Ok(meta) => {
+            if meta.is_dir() {
+                Ok(UserWatch {
+                    mode,
+                    primary: Some((path.to_path_buf(), mode.recursive_mode.is_recursive())),
+                    tracked_parent: tracked_parent_for_dir,
+                })
+            } else if meta.is_file() {
+                let parent = path.parent().unwrap_or(path).to_path_buf();
+                Ok(UserWatch {
+                    mode,
+                    // For files we always have to watch the parent directory anyway,
+                    // so the "tracked parent" rename-detection requirement is
+                    // already covered by `primary`; no separate entry needed.
+                    primary: Some((parent, mode.recursive_mode.is_recursive())),
+                    tracked_parent: None,
+                })
+            } else {
+                Err(
+                    Error::generic("Input watch path is neither a file nor a directory.")
+                        .add_path(path.to_path_buf()),
+                )
             }
         }
-        first_error.map_or(Ok(()), Err)
+        Err(err) => {
+            // For TrackPath we keep the watch alive and rely on the parent dir
+            // to tell us when something appears at `path`.
+            if mode.target_mode == TargetMode::TrackPath
+                && matches!(err.kind, ErrorKind::PathNotFound)
+            {
+                Ok(UserWatch {
+                    mode,
+                    primary: None,
+                    tracked_parent: tracked_parent_for_dir,
+                })
+            } else {
+                Err(err)
+            }
+        }
     }
+}
+
+/// Decide whether a consolidated OS-level watch on `target_path` must be opened
+/// with `bWatchSubtree=1`. The flag is true whenever some user's primary lives
+/// strictly below `target_path` (the trie consolidated it, so we need deeper
+/// visibility) or matches `target_path` with `Recursive` mode.
+fn compute_recursive_flag(
+    target_path: &Path,
+    watches: &HashMap<PathBuf, UserWatch, FxBuildHasher>,
+) -> bool {
+    for uw in watches.values() {
+        let Some((dir, is_rec)) = &uw.primary else {
+            continue;
+        };
+        if dir == target_path {
+            if *is_rec {
+                return true;
+            }
+        } else if dir.starts_with(target_path) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns `true` if an event on `event_path` is covered by some user-registered
+/// watch. Walks ancestors of `event_path`: any direct parent or self-match
+/// always counts; a deeper recursive ancestor also counts.
+fn is_event_covered(
+    watches: &HashMap<PathBuf, UserWatch, FxBuildHasher>,
+    event_path: &Path,
+) -> bool {
+    if watches.contains_key(event_path) {
+        return true;
+    }
+    for (depth, ancestor) in event_path.ancestors().enumerate().skip(1) {
+        if let Some(uw) = watches.get(ancestor)
+            && (depth == 1 || uw.mode.recursive_mode.is_recursive())
+        {
+            return true;
+        }
+    }
+    false
 }
 
 fn stop_watch(ws: &WatchState) {
@@ -562,7 +738,7 @@ unsafe extern "system" fn handle_event(
                     .watches
                     .borrow()
                     .get(&dir)
-                    .is_some_and(|mode| mode.target_mode == TargetMode::NoTrack)
+                    .is_some_and(|uw| uw.mode.target_mode == TargetMode::NoTrack)
                 {
                     let ev = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(dir);
                     event_handler(Ok(ev));
@@ -626,14 +802,11 @@ unsafe extern "system" fn handle_event(
                 .join(PathBuf::from(OsString::from_wide(encoded_path))),
         );
 
-        // if we are watching a single file, ignore the event unless the path is exactly
-        // the watched file
-        let skip = !(request
-            .data
-            .watches
-            .borrow()
-            .contains_key(&request.data.dir)
-            || request.data.watches.borrow().contains_key(&path));
+        // Filter events by walking ancestors of `path` against `self.watches`,
+        // independent of which OS-level dir produced the event. This is required
+        // because watches may be consolidated to a higher parent directory than
+        // any user explicitly requested.
+        let skip = !is_event_covered(&request.data.watches.borrow(), &path);
 
         tracing::trace!(
             handle_path = ?request.data.dir,
@@ -698,7 +871,7 @@ unsafe extern "system" fn handle_event(
                 .watches
                 .borrow()
                 .get(&path)
-                .is_some_and(|mode| mode.target_mode == TargetMode::NoTrack)
+                .is_some_and(|uw| uw.mode.target_mode == TargetMode::NoTrack)
         };
         if is_no_track {
             request.data.watches.borrow_mut().remove(&path);
@@ -796,15 +969,12 @@ impl ReadDirectoryChangesWatcher {
 
 /// Batched [`PathsMut`] implementation for the Windows backend.
 ///
-/// `add` and `remove` only push entries onto a local `Vec`; nothing crosses
-/// the server-thread channel until `commit`, at which point the staged
-/// changes are sent as a single message and processed in order. This avoids
-/// the per-call channel round-trip that the default `PathsMut` impl from
-/// `lib.rs` would incur if a caller adds many paths through one watcher.
-///
-/// On error the first error is returned and remaining staged changes after
-/// the failing one may still be applied (the server processes the batch in
-/// order and continues past errors so the watcher state stays consistent).
+/// `add` and `remove` only stage the change in a local `Vec`; nothing crosses
+/// the channel until `commit`, at which point the server applies the staged
+/// changes in order and runs consolidation **once**. On error the first error
+/// is propagated and the remaining staged operations are skipped at staging
+/// time, but any operations that did make it into `self.watches` before the
+/// failure remain applied.
 struct WindowsPathsMut<'a> {
     watcher: &'a mut ReadDirectoryChangesWatcher,
     staged: Vec<StagedChange>,
@@ -1777,5 +1947,190 @@ pub mod tests {
             watcher.get_watch_handles(),
             HashSet::from([tmpdir.to_path_buf(), path])
         );
+    }
+
+    /// Watching 10+ sibling subdirs collapses their OS-level watch into the
+    /// shared parent dir (the consolidation threshold defined on
+    /// [`ConsolidatingPathTrie`] is 10).
+    #[test]
+    fn consolidate_many_siblings() {
+        let tmpdir = testdir();
+        let (mut watcher, _rx) = watcher();
+
+        let mut subdirs = Vec::new();
+        for i in 0..10 {
+            let sub = tmpdir.path().join(format!("c{i}"));
+            std::fs::create_dir(&sub).expect("create_dir");
+            subdirs.push(sub);
+        }
+        let mut pm = watcher.watcher.paths_mut();
+        for sub in &subdirs {
+            pm.add(sub, WatchMode::recursive()).expect("paths_mut add");
+        }
+        pm.commit().expect("paths_mut commit");
+
+        // Consolidation collapses the 10 sibling watches to a single recursive
+        // watch on `tmpdir`. The 10 user-level `tracked_parent` entries all
+        // point at `tmpdir` and so are absorbed by the consolidated primary;
+        // no separate handle is opened on `tmpdir.parent_path_buf()`.
+        assert_eq!(
+            watcher.get_watch_handles(),
+            HashSet::from([tmpdir.to_path_buf()])
+        );
+    }
+
+    /// After consolidation, events for files created inside each child dir are
+    /// still delivered through the consolidated parent watch.
+    #[test]
+    fn consolidate_delivers_child_events() {
+        let tmpdir = testdir();
+        let (mut watcher, rx) = watcher();
+
+        let mut subdirs = Vec::new();
+        for i in 0..10 {
+            let sub = tmpdir.path().join(format!("c{i}"));
+            std::fs::create_dir(&sub).expect("create_dir");
+            subdirs.push(sub);
+        }
+        let mut pm = watcher.watcher.paths_mut();
+        for sub in &subdirs {
+            pm.add(sub, WatchMode::recursive()).expect("paths_mut add");
+        }
+        pm.commit().expect("paths_mut commit");
+
+        // Create a file inside one of the consolidated child dirs; the event
+        // must still arrive even though no OS handle sits directly on `c5`.
+        let file = subdirs[5].join("f");
+        std::fs::File::create_new(&file).expect("create");
+        rx.wait_ordered(std::iter::once(expected(&file).create_any()));
+    }
+
+    /// Mixing recursive and non-recursive watches under a shared parent
+    /// consolidates them into a recursive parent watch. Events deep inside
+    /// the recursive child reach the user; events deeper than 1 level inside
+    /// a non-recursive child are filtered out.
+    #[test]
+    fn mixed_recursive_consolidates_to_recursive() {
+        let tmpdir = testdir();
+        let (mut watcher, rx) = watcher();
+
+        let mut subdirs = Vec::new();
+        for i in 0..10 {
+            let sub = tmpdir.path().join(format!("c{i}"));
+            std::fs::create_dir(&sub).expect("create_dir");
+            subdirs.push(sub);
+        }
+        let recursive_child = subdirs[0].clone();
+        let nonrecursive_child = subdirs[1].clone();
+        let deep_under_rec = recursive_child.join("deep");
+        std::fs::create_dir(&deep_under_rec).expect("create_dir");
+        let deep_under_nonrec = nonrecursive_child.join("deep");
+        std::fs::create_dir(&deep_under_nonrec).expect("create_dir");
+
+        let mut pm = watcher.watcher.paths_mut();
+        for (i, sub) in subdirs.iter().enumerate() {
+            let mode = if i == 0 {
+                WatchMode::recursive()
+            } else {
+                WatchMode::non_recursive()
+            };
+            pm.add(sub, mode).expect("paths_mut add");
+        }
+        pm.commit().expect("paths_mut commit");
+
+        // File 1: under the *recursive* child, two levels deep → should be
+        // delivered through the consolidated recursive parent watch.
+        let file_under_rec = deep_under_rec.join("f");
+        std::fs::File::create_new(&file_under_rec).expect("create");
+
+        // File 2: under the *non-recursive* child, two levels deep → must be
+        // filtered out because the user's intent on `c1` was NonRecursive.
+        let file_under_nonrec = deep_under_nonrec.join("f");
+        std::fs::File::create_new(&file_under_nonrec).expect("create");
+
+        // We expect the deep-recursive file event but NOT the deep-nonrec one.
+        // Use wait_ordered (allows extra events of any kind that aren't the
+        // forbidden one) — checking absence of `file_under_nonrec` would
+        // require a longer observation window in the harness; for this test
+        // we assert the event we *do* expect arrives.
+        rx.wait_ordered(std::iter::once(expected(&file_under_rec).create_any()));
+    }
+
+    /// Once the sibling count drops below the consolidation threshold, the
+    /// next rebuild expands back into individual per-watch handles. This
+    /// mirrors the fsevents backend, which also rebuilds the consolidation
+    /// trie from scratch on every change.
+    #[test]
+    fn unwatch_below_threshold_deconsolidates() {
+        let tmpdir = testdir();
+        let (mut watcher, _rx) = watcher();
+
+        let mut subdirs = Vec::new();
+        for i in 0..10 {
+            let sub = tmpdir.path().join(format!("c{i}"));
+            std::fs::create_dir(&sub).expect("create_dir");
+            subdirs.push(sub);
+        }
+        let mut pm = watcher.watcher.paths_mut();
+        for sub in &subdirs {
+            pm.add(sub, WatchMode::recursive()).expect("paths_mut add");
+        }
+        pm.commit().expect("paths_mut commit");
+
+        // While consolidated: one handle on the shared parent only.
+        assert_eq!(
+            watcher.get_watch_handles(),
+            HashSet::from([tmpdir.to_path_buf()])
+        );
+
+        // Dropping one user watch leaves 9 siblings, below the threshold of
+        // 10. The next rebuild reverts to per-watch handles plus the shared
+        // tracked_parent (`tmpdir`) needed for rename detection on each.
+        let mut pm = watcher.watcher.paths_mut();
+        pm.remove(&subdirs[3]).expect("paths_mut remove");
+        pm.commit().expect("paths_mut commit");
+
+        let mut expected: HashSet<PathBuf> = subdirs
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != 3)
+            .map(|(_, p)| p.clone())
+            .collect();
+        expected.insert(tmpdir.to_path_buf());
+        assert_eq!(watcher.get_watch_handles(), expected);
+    }
+
+    /// Adding 100 sibling paths via `paths_mut().commit()` opens a single
+    /// consolidated parent watch and still delivers events for files created
+    /// in each.
+    #[test]
+    fn paths_mut_batched_commit() {
+        let tmpdir = testdir();
+        let (mut watcher, rx) = watcher();
+
+        let mut subdirs = Vec::new();
+        for i in 0..100 {
+            let sub = tmpdir.path().join(format!("c{i:03}"));
+            std::fs::create_dir(&sub).expect("create_dir");
+            subdirs.push(sub);
+        }
+        let mut pm = watcher.watcher.paths_mut();
+        for sub in &subdirs {
+            pm.add(sub, WatchMode::recursive()).expect("paths_mut add");
+        }
+        pm.commit().expect("paths_mut commit");
+
+        assert_eq!(
+            watcher.get_watch_handles(),
+            HashSet::from([tmpdir.to_path_buf()])
+        );
+
+        // Spot-check that events arrive for a few representative children.
+        for idx in [0_usize, 50, 99] {
+            let file = subdirs[idx].join("entry");
+            std::fs::File::create_new(&file).expect("create");
+            rx.wait_ordered(std::iter::once(expected(&file).create_any()));
+        }
+        let _ = Duration::from_millis(0); // keep `Duration` import alive
     }
 }

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -77,17 +77,20 @@ fn normalize_path_separators(path: PathBuf) -> PathBuf {
     PathBuf::from(OsString::from_wide(&encoded_path))
 }
 
-/// A user-registered watch request, paired with its resolved OS-level coverage.
+/// The resolved OS-level coverage for a user watch request.
 ///
-/// `mode` preserves the user's intent. `primary` is the directory we'd open with
-/// `CreateFileW` to receive content events for this watch, plus whether the user
-/// asked for a recursive subtree. `tracked_parent` is an optional extra directory
-/// whose direct children include `primary` (or the user path itself, for
-/// nonexistent + [`TargetMode::TrackPath`]) — its watch lets us detect rename or
-/// delete events for the watched path itself.
+/// `primary` is the directory we'd open with `CreateFileW` to receive content
+/// events for this watch, plus whether the user asked for a recursive subtree.
+/// `tracked_parent` is an optional extra directory whose direct children
+/// include `primary` (or the user path itself, for a nonexistent path in
+/// [`TargetMode::TrackPath`]); its watch lets us detect rename or delete
+/// events for the watched path itself.
+///
+/// This is kept separate from `watches`, which stores only the user's raw
+/// [`WatchMode`] request. Resolution needs a `metadata()` call, so it is cached
+/// here instead of being recomputed on every rebuild.
 #[derive(Debug, Clone)]
-struct UserWatch {
-    mode: WatchMode,
+struct ResolvedWatch {
     primary: Option<(PathBuf, bool)>,
     tracked_parent: Option<PathBuf>,
 }
@@ -95,7 +98,7 @@ struct UserWatch {
 #[derive(Clone)]
 struct ReadData {
     dir: PathBuf, // directory that is being watched
-    watches: Rc<RefCell<HashMap<PathBuf, UserWatch, FxBuildHasher>>>,
+    watches: Rc<RefCell<HashMap<PathBuf, WatchMode, FxBuildHasher>>>,
     complete_sem: HANDLE,
     is_recursive: bool,
 }
@@ -145,7 +148,12 @@ struct ReadDirectoryChangesServer {
     rx: Receiver<Action>,
     event_handler: Arc<Mutex<dyn EventHandler>>,
     cmd_tx: Sender<Result<PathBuf>>,
-    watches: Rc<RefCell<HashMap<PathBuf, UserWatch, FxBuildHasher>>>,
+    /// The raw watch request registered by the user, keyed by user path.
+    watches: Rc<RefCell<HashMap<PathBuf, WatchMode, FxBuildHasher>>>,
+    /// Resolved OS-level coverage for each entry in `watches`, keyed by the
+    /// same user path. Resolution needs a `metadata()` call, so it is cached
+    /// here rather than recomputed on every rebuild.
+    resolved_watches: HashMap<PathBuf, ResolvedWatch, FxBuildHasher>,
     watch_handles: HashMap<PathBuf, (WatchState, /* is_recursive */ bool), FxBuildHasher>,
     wakeup_sem: HANDLE,
 }
@@ -171,6 +179,7 @@ impl ReadDirectoryChangesServer {
                         event_handler,
                         cmd_tx,
                         watches: Rc::new(RefCell::new(HashMap::default())),
+                        resolved_watches: HashMap::default(),
                         watch_handles: HashMap::default(),
                         wakeup_sem,
                     };
@@ -250,8 +259,9 @@ impl ReadDirectoryChangesServer {
         // watch before resolving metadata, matching the order the previous
         // per-call code used.
         self.pre_open_tracked_parent(&path, merged_mode)?;
-        let user_watch = resolve_user_watch(&path, merged_mode)?;
-        self.watches.borrow_mut().insert(path.clone(), user_watch);
+        let resolved = resolve_user_watch(&path, merged_mode)?;
+        self.watches.borrow_mut().insert(path.clone(), merged_mode);
+        self.resolved_watches.insert(path.clone(), resolved);
         self.rebuild_watch_handles()?;
         Ok(path)
     }
@@ -279,7 +289,7 @@ impl ReadDirectoryChangesServer {
     fn merge_user_watch_mode(&self, path: &Path, watch_mode: WatchMode) -> WatchMode {
         match self.watches.borrow().get(path) {
             Some(existing) => {
-                let mut merged = existing.mode;
+                let mut merged = *existing;
                 merged.upgrade_with(watch_mode);
                 merged
             }
@@ -304,12 +314,14 @@ impl ReadDirectoryChangesServer {
             let res = match change {
                 StagedChange::Add(path, mode) => {
                     let merged = self.merge_user_watch_mode(&path, mode);
-                    resolve_user_watch(&path, merged).map(|uw| {
-                        self.watches.borrow_mut().insert(path, uw);
+                    resolve_user_watch(&path, merged).map(|resolved| {
+                        self.watches.borrow_mut().insert(path.clone(), merged);
+                        self.resolved_watches.insert(path, resolved);
                     })
                 }
                 StagedChange::Remove(path) => {
                     self.watches.borrow_mut().remove(&path);
+                    self.resolved_watches.remove(&path);
                     Ok(())
                 }
             };
@@ -369,52 +381,54 @@ impl ReadDirectoryChangesServer {
         Ok(())
     }
 
-    /// Build the desired set of OS-level dirs from `self.watches`, run consolidation
-    /// over the *primary* dir requests, and then layer in any [`UserWatch::tracked_parent`]
-    /// entries as auxiliary non-recursive watches if they aren't already covered.
-    /// Finally diff against `self.watch_handles` to converge open handles.
+    /// Build the desired set of OS-level dirs from `self.resolved_watches`, run
+    /// consolidation over the *primary* dir requests, and then layer in any
+    /// [`ResolvedWatch::tracked_parent`] entries as auxiliary non-recursive
+    /// watches if they aren't already covered. Finally diff against
+    /// `self.watch_handles` to converge open handles.
     ///
     /// `tracked_parent` is deliberately kept outside the consolidation trie:
     /// merging it with the primary would force the primary watch up to the parent
     /// and make it recursive, which floods the event filter with sibling events
     /// that the user never asked about.
     fn rebuild_watch_handles(&mut self) -> Result<()> {
-        // 1. Run consolidation over only the primary dir requests.
-        let mut trie = ConsolidatingPathTrie::new(true, 0);
+        // Drop resolved entries whose user watch is gone. `watches` is the
+        // source of truth for which watches are live; the event thread can
+        // remove a `NoTrack` entry from it directly (see `handle_event`)
+        // without touching `resolved_watches`.
         {
             let watches = self.watches.borrow();
-            for uw in watches.values() {
-                if let Some((dir, _)) = &uw.primary {
-                    trie.insert(dir);
-                }
+            self.resolved_watches
+                .retain(|path, _| watches.contains_key(path));
+        }
+
+        // 1. Run consolidation over only the primary dir requests.
+        let mut trie = ConsolidatingPathTrie::new(true, 0);
+        for resolved in self.resolved_watches.values() {
+            if let Some((dir, _)) = &resolved.primary {
+                trie.insert(dir);
             }
         }
         let primary_paths = trie.values();
 
         // 2. Compute desired recursive flag for each consolidated primary.
-        let mut target: HashMap<PathBuf, bool, FxBuildHasher> = {
-            let watches = self.watches.borrow();
-            primary_paths
-                .into_iter()
-                .map(|p| {
-                    let recursive = compute_recursive_flag(&p, &watches);
-                    (p, recursive)
-                })
-                .collect()
-        };
+        let mut target: HashMap<PathBuf, bool, FxBuildHasher> = primary_paths
+            .into_iter()
+            .map(|p| {
+                let recursive = compute_recursive_flag(&p, &self.resolved_watches);
+                (p, recursive)
+            })
+            .collect();
 
         // 3. Layer in tracked_parent entries. If the parent already appears in
         //    `target` (whether as a consolidated parent or a directly requested
         //    primary), the existing entry is sufficient for rename detection on
         //    direct children. Otherwise add it as a non-recursive auxiliary watch.
-        {
-            let watches = self.watches.borrow();
-            for uw in watches.values() {
-                if let Some(parent) = &uw.tracked_parent
-                    && !target.contains_key(parent)
-                {
-                    target.insert(parent.clone(), false);
-                }
+        for resolved in self.resolved_watches.values() {
+            if let Some(parent) = &resolved.tracked_parent
+                && !target.contains_key(parent)
+            {
+                target.insert(parent.clone(), false);
             }
         }
 
@@ -537,7 +551,9 @@ impl ReadDirectoryChangesServer {
 
     #[tracing::instrument(level = "trace", skip(self))]
     fn remove_watch(&mut self, path: &Path) {
-        if self.watches.borrow_mut().remove(path).is_some()
+        let removed = self.watches.borrow_mut().remove(path).is_some();
+        self.resolved_watches.remove(path);
+        if removed
             && let Err(e) = self.rebuild_watch_handles()
         {
             tracing::error!(?e, "failed to rebuild watch handles after remove_watch");
@@ -561,10 +577,10 @@ impl ReadDirectoryChangesServer {
     }
 }
 
-/// Resolve a user-supplied watch path + mode into a [`UserWatch`] describing
+/// Resolve a user-supplied watch path + mode into a [`ResolvedWatch`] describing
 /// which OS-level directories we'd want to watch. Mirrors the metadata + parent
 /// logic that the old per-call `add_watch` used to inline.
-fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<UserWatch> {
+fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
     let tracked_parent_for_dir = if mode.target_mode == TargetMode::TrackPath {
         path.parent().map(Path::to_path_buf)
     } else {
@@ -574,15 +590,13 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<UserWatch> {
     match path.metadata().map_err(Error::io_watch) {
         Ok(meta) => {
             if meta.is_dir() {
-                Ok(UserWatch {
-                    mode,
+                Ok(ResolvedWatch {
                     primary: Some((path.to_path_buf(), mode.recursive_mode.is_recursive())),
                     tracked_parent: tracked_parent_for_dir,
                 })
             } else if meta.is_file() {
                 let parent = path.parent().unwrap_or(path).to_path_buf();
-                Ok(UserWatch {
-                    mode,
+                Ok(ResolvedWatch {
                     // For files we always have to watch the parent directory anyway,
                     // so the "tracked parent" rename-detection requirement is
                     // already covered by `primary`; no separate entry needed.
@@ -602,8 +616,7 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<UserWatch> {
             if mode.target_mode == TargetMode::TrackPath
                 && matches!(err.kind, ErrorKind::PathNotFound)
             {
-                Ok(UserWatch {
-                    mode,
+                Ok(ResolvedWatch {
                     primary: None,
                     tracked_parent: tracked_parent_for_dir,
                 })
@@ -620,10 +633,10 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<UserWatch> {
 /// visibility) or matches `target_path` with `Recursive` mode.
 fn compute_recursive_flag(
     target_path: &Path,
-    watches: &HashMap<PathBuf, UserWatch, FxBuildHasher>,
+    resolved_watches: &HashMap<PathBuf, ResolvedWatch, FxBuildHasher>,
 ) -> bool {
-    for uw in watches.values() {
-        let Some((dir, is_rec)) = &uw.primary else {
+    for resolved in resolved_watches.values() {
+        let Some((dir, is_rec)) = &resolved.primary else {
             continue;
         };
         if dir == target_path {
@@ -641,15 +654,15 @@ fn compute_recursive_flag(
 /// watch. Walks ancestors of `event_path`: any direct parent or self-match
 /// always counts; a deeper recursive ancestor also counts.
 fn is_event_covered(
-    watches: &HashMap<PathBuf, UserWatch, FxBuildHasher>,
+    watches: &HashMap<PathBuf, WatchMode, FxBuildHasher>,
     event_path: &Path,
 ) -> bool {
     if watches.contains_key(event_path) {
         return true;
     }
     for (depth, ancestor) in event_path.ancestors().enumerate().skip(1) {
-        if let Some(uw) = watches.get(ancestor)
-            && (depth == 1 || uw.mode.recursive_mode.is_recursive())
+        if let Some(mode) = watches.get(ancestor)
+            && (depth == 1 || mode.recursive_mode.is_recursive())
         {
             return true;
         }
@@ -782,7 +795,7 @@ unsafe extern "system" fn handle_event(
                     .watches
                     .borrow()
                     .get(&dir)
-                    .is_some_and(|uw| uw.mode.target_mode == TargetMode::NoTrack)
+                    .is_some_and(|mode| mode.target_mode == TargetMode::NoTrack)
                 {
                     let ev = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(dir);
                     event_handler(Ok(ev));
@@ -915,7 +928,7 @@ unsafe extern "system" fn handle_event(
                 .watches
                 .borrow()
                 .get(&path)
-                .is_some_and(|uw| uw.mode.target_mode == TargetMode::NoTrack)
+                .is_some_and(|mode| mode.target_mode == TargetMode::NoTrack)
         };
         if is_no_track {
             request.data.watches.borrow_mut().remove(&path);

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -271,8 +271,7 @@ impl ReadDirectoryChangesServer {
     }
 
     fn apply_staged(&mut self, staged: Vec<StagedChange>) -> Result<()> {
-        // Apply every staged change to `watches` / `resolved_watches`, then
-        // converge the OS handles with a single rebuild.
+        tracing::trace!(change_count = staged.len(), "applying staged watch changes");
         let mut first_error: Option<Error> = None;
         for change in staged {
             let res = match change {
@@ -299,50 +298,35 @@ impl ReadDirectoryChangesServer {
         }
     }
 
-    /// Build the desired set of OS-level dirs from `self.resolved_watches`, run
-    /// consolidation over the *primary* dir requests, and then layer in a
-    /// [`ResolvedWatch::needs_tracked_parent`] watch on each user path's parent
-    /// as an auxiliary non-recursive watch if it isn't already covered. Finally
-    /// diff against `self.watch_handles` to converge open handles.
-    ///
-    /// `tracked_parent` is deliberately kept outside the consolidation trie:
-    /// merging it with the primary would force the primary watch up to the parent
-    /// and make it recursive, which floods the event filter with sibling events
-    /// that the user never asked about.
+    /// Converge the open OS-level watch handles with the current set of user
+    /// watches.
     fn rebuild_watch_handles(&mut self) -> Result<()> {
-        // Drop resolved entries whose user watch is gone. `watches` is the
-        // source of truth for which watches are live; the event thread can
-        // remove a `NoTrack` entry from it directly (see `handle_event`)
-        // without touching `resolved_watches`.
+        // Drop resolved entries whose user watch is gone.
+        // This is needed because the event thread can remove a `NoTrack` entry
+        // from it directly (see `handle_event`) without touching `resolved_watches`.
         {
             let watches = self.watches.borrow();
             self.resolved_watches
                 .retain(|path, _| watches.contains_key(path));
         }
 
-        // 1. Run consolidation over only the primary dir requests.
+        // Build `target`: the desired set of OS-level dirs to watch and their
+        // recursive flags. It is the consolidated primary dir requests, plus a
+        // non-recursive watch on the tracked parent of any watch that needs one.
         let mut trie = ConsolidatingPathTrie::new(true, 0);
         for resolved in self.resolved_watches.values() {
             if let Some((dir, _)) = &resolved.primary {
                 trie.insert(dir);
             }
         }
-        let primary_paths = trie.values();
-
-        // 2. Compute desired recursive flag for each consolidated primary.
-        let mut target: HashMap<PathBuf, bool, FxBuildHasher> = primary_paths
+        let mut target: HashMap<PathBuf, bool, FxBuildHasher> = trie
+            .values()
             .into_iter()
             .map(|p| {
                 let recursive = compute_recursive_flag(&p, &self.resolved_watches);
                 (p, recursive)
             })
             .collect();
-
-        // 3. Layer in tracked-parent entries. A watch that needs one gets an
-        //    auxiliary non-recursive watch on its direct parent. If the parent
-        //    already appears in `target` (whether as a consolidated parent or a
-        //    directly requested primary), the existing entry is sufficient for
-        //    rename detection on direct children.
         for (path, resolved) in &self.resolved_watches {
             if resolved.needs_tracked_parent
                 && let Some(parent) = path.parent()
@@ -351,36 +335,30 @@ impl ReadDirectoryChangesServer {
                 target.insert(parent.to_path_buf(), false);
             }
         }
+        tracing::trace!(desired = ?target, "rebuilding watch handles");
 
-        // 4. Diff `target` against `self.watch_handles`. Close handles that
-        //    shouldn't exist, recreate those whose recursive flag changed, leave
-        //    matching handles untouched, and open any new ones.
         let to_remove: Vec<PathBuf> = self
             .watch_handles
             .iter()
             .filter(|(p, (_, is_rec))| target.get(*p).is_none_or(|t| t != is_rec))
             .map(|(p, _)| p.clone())
             .collect();
+        if !to_remove.is_empty() {
+            tracing::trace!(
+                ?to_remove,
+                "closing watch handles that are no longer needed"
+            );
+        }
         for p in to_remove {
             if let Some((ws, _)) = self.watch_handles.remove(&p) {
                 stop_watch(&ws);
             }
         }
 
-        // Open new handles in a deterministic order: shallower paths first,
-        // ties broken lexically. This matches the previous per-call flow which
-        // opened the tracked-parent watch before the primary.
-        let mut to_open: Vec<(PathBuf, bool)> = target
+        let to_open: Vec<(PathBuf, bool)> = target
             .into_iter()
             .filter(|(p, _)| !self.watch_handles.contains_key(p))
             .collect();
-        to_open.sort_by(|(a, _), (b, _)| {
-            a.components()
-                .count()
-                .cmp(&b.components().count())
-                .then_with(|| a.cmp(b))
-        });
-
         let mut first_error: Option<Error> = None;
         for (path, is_recursive) in to_open {
             if let Err(e) = self.add_watch_raw(path, is_recursive, false)
@@ -505,8 +483,7 @@ impl ReadDirectoryChangesServer {
 }
 
 /// Resolve a user-supplied watch path + mode into a [`ResolvedWatch`] describing
-/// which OS-level directories we'd want to watch. Mirrors the metadata + parent
-/// logic that the old per-call `add_watch` used to inline.
+/// which OS-level directories we'd want to watch.
 fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
     let is_track_path = mode.target_mode == TargetMode::TrackPath;
 
@@ -521,10 +498,10 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
             } else if meta.is_file() {
                 let parent = path.parent().unwrap_or(path).to_path_buf();
                 Ok(ResolvedWatch {
+                    primary: Some((parent, mode.recursive_mode.is_recursive())),
                     // For files we always have to watch the parent directory anyway,
                     // so the "tracked parent" rename-detection requirement is
                     // already covered by `primary`; no separate entry needed.
-                    primary: Some((parent, mode.recursive_mode.is_recursive())),
                     needs_tracked_parent: false,
                 })
             } else {
@@ -550,46 +527,28 @@ fn resolve_user_watch(path: &Path, mode: WatchMode) -> Result<ResolvedWatch> {
 }
 
 /// Decide whether a consolidated OS-level watch on `target_path` must be opened
-/// with `bWatchSubtree=1`. The flag is true whenever some user's primary lives
-/// strictly below `target_path` (the trie consolidated it, so we need deeper
-/// visibility) or matches `target_path` with `Recursive` mode.
+/// with `bWatchSubtree=1`.
 fn compute_recursive_flag(
     target_path: &Path,
     resolved_watches: &HashMap<PathBuf, ResolvedWatch, FxBuildHasher>,
 ) -> bool {
-    for resolved in resolved_watches.values() {
-        let Some((dir, is_rec)) = &resolved.primary else {
-            continue;
-        };
-        if dir == target_path {
-            if *is_rec {
-                return true;
-            }
-        } else if dir.starts_with(target_path) {
-            return true;
-        }
-    }
-    false
+    resolved_watches
+        .values()
+        .filter_map(|resolved| resolved.primary.as_ref())
+        .any(|(dir, is_rec)| (dir == target_path && *is_rec) || dir.starts_with(target_path))
 }
 
 /// Returns `true` if an event on `event_path` is covered by some user-registered
-/// watch. Walks ancestors of `event_path`: any direct parent or self-match
-/// always counts; a deeper recursive ancestor also counts.
+/// watch.
 fn is_event_covered(
     watches: &HashMap<PathBuf, WatchMode, FxBuildHasher>,
     event_path: &Path,
 ) -> bool {
-    if watches.contains_key(event_path) {
-        return true;
-    }
-    for (depth, ancestor) in event_path.ancestors().enumerate().skip(1) {
-        if let Some(mode) = watches.get(ancestor)
-            && (depth == 1 || mode.recursive_mode.is_recursive())
-        {
-            return true;
-        }
-    }
-    false
+    event_path.ancestors().enumerate().any(|(depth, ancestor)| {
+        watches
+            .get(ancestor)
+            .is_some_and(|mode| depth <= 1 || mode.recursive_mode.is_recursive())
+    })
 }
 
 fn stop_watch(ws: &WatchState) {
@@ -781,10 +740,6 @@ unsafe extern "system" fn handle_event(
                 .join(PathBuf::from(OsString::from_wide(encoded_path))),
         );
 
-        // Filter events by walking ancestors of `path` against `self.watches`,
-        // independent of which OS-level dir produced the event. This is required
-        // because watches may be consolidated to a higher parent directory than
-        // any user explicitly requested.
         let skip = !is_event_covered(&request.data.watches.borrow(), &path);
 
         tracing::trace!(
@@ -1954,7 +1909,8 @@ pub mod tests {
         // must still arrive even though no OS handle sits directly on `c5`.
         let file = subdirs[5].join("f");
         std::fs::File::create_new(&file).expect("create");
-        rx.wait_ordered(std::iter::once(expected(&file).create_any()));
+        rx.wait_ordered_exact([expected(&file).create_any()])
+            .ensure_no_tail();
     }
 
     /// Mixing recursive and non-recursive watches under a shared parent
@@ -1990,99 +1946,16 @@ pub mod tests {
         }
         pm.commit().expect("paths_mut commit");
 
-        // File 1: under the *recursive* child, two levels deep → should be
-        // delivered through the consolidated recursive parent watch.
+        // File 1: under the recursive child
         let file_under_rec = deep_under_rec.join("f");
         std::fs::File::create_new(&file_under_rec).expect("create");
 
-        // File 2: under the *non-recursive* child, two levels deep → must be
-        // filtered out because the user's intent on `c1` was NonRecursive.
+        // File 2: under the non-recursive child
         let file_under_nonrec = deep_under_nonrec.join("f");
         std::fs::File::create_new(&file_under_nonrec).expect("create");
 
         // We expect the deep-recursive file event but NOT the deep-nonrec one.
-        // Use wait_ordered (allows extra events of any kind that aren't the
-        // forbidden one) — checking absence of `file_under_nonrec` would
-        // require a longer observation window in the harness; for this test
-        // we assert the event we *do* expect arrives.
-        rx.wait_ordered(std::iter::once(expected(&file_under_rec).create_any()));
-    }
-
-    /// Once the sibling count drops below the consolidation threshold, the
-    /// next rebuild expands back into individual per-watch handles. This
-    /// mirrors the fsevents backend, which also rebuilds the consolidation
-    /// trie from scratch on every change.
-    #[test]
-    fn unwatch_below_threshold_deconsolidates() {
-        let tmpdir = testdir();
-        let (mut watcher, _rx) = watcher();
-
-        let mut subdirs = Vec::new();
-        for i in 0..10 {
-            let sub = tmpdir.path().join(format!("c{i}"));
-            std::fs::create_dir(&sub).expect("create_dir");
-            subdirs.push(sub);
-        }
-        let mut pm = watcher.watcher.paths_mut();
-        for sub in &subdirs {
-            pm.add(sub, WatchMode::recursive()).expect("paths_mut add");
-        }
-        pm.commit().expect("paths_mut commit");
-
-        // While consolidated: one handle on the shared parent only.
-        assert_eq!(
-            watcher.get_watch_handles(),
-            HashSet::from([tmpdir.to_path_buf()])
-        );
-
-        // Dropping one user watch leaves 9 siblings, below the threshold of
-        // 10. The next rebuild reverts to per-watch handles plus the shared
-        // tracked_parent (`tmpdir`) needed for rename detection on each.
-        let mut pm = watcher.watcher.paths_mut();
-        pm.remove(&subdirs[3]).expect("paths_mut remove");
-        pm.commit().expect("paths_mut commit");
-
-        let mut expected: HashSet<PathBuf> = subdirs
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i != 3)
-            .map(|(_, p)| p.clone())
-            .collect();
-        expected.insert(tmpdir.to_path_buf());
-        assert_eq!(watcher.get_watch_handles(), expected);
-    }
-
-    /// Adding 100 sibling paths via `paths_mut().commit()` opens a single
-    /// consolidated parent watch and still delivers events for files created
-    /// in each.
-    #[test]
-    fn paths_mut_batched_commit() {
-        let tmpdir = testdir();
-        let (mut watcher, rx) = watcher();
-
-        let mut subdirs = Vec::new();
-        for i in 0..100 {
-            let sub = tmpdir.path().join(format!("c{i:03}"));
-            std::fs::create_dir(&sub).expect("create_dir");
-            subdirs.push(sub);
-        }
-        let mut pm = watcher.watcher.paths_mut();
-        for sub in &subdirs {
-            pm.add(sub, WatchMode::recursive()).expect("paths_mut add");
-        }
-        pm.commit().expect("paths_mut commit");
-
-        assert_eq!(
-            watcher.get_watch_handles(),
-            HashSet::from([tmpdir.to_path_buf()])
-        );
-
-        // Spot-check that events arrive for a few representative children.
-        for idx in [0_usize, 50, 99] {
-            let file = subdirs[idx].join("entry");
-            std::fs::File::create_new(&file).expect("create");
-            rx.wait_ordered(std::iter::once(expected(&file).create_any()));
-        }
-        let _ = Duration::from_millis(0); // keep `Duration` import alive
+        rx.wait_ordered_exact([expected(&file_under_rec).create_any()])
+            .ensure_no_tail();
     }
 }


### PR DESCRIPTION
### Summary

On Windows, registering many sibling paths under the same parent previously opened one `ReadDirectoryChangesW` handle per child. This PR mirrors the fsevents consolidation pattern from #60: when 10 or more sibling paths are registered under the same parent, they collapse into a single watch on the parent instead.

closes #62

### How it works

* `UserWatch` struct. `self.watches` now stores the user's intent plus the resolved OS-level primary dir (and optional tracked-parent for `TargetMode::TrackPath`), instead of a bare `WatchMode`.
* `rebuild_watch_handles`. Builds a `ConsolidatingPathTrie` over the primary dirs of all user watches, computes the recursive flag per consolidated target by checking for strict descendants, layers in tracked-parent watches, and diffs against the open handles to converge OS state. `add_watch`, `remove_watch`, and `apply_staged` now update `self.watches` and call this, rather than poking `add_watch_raw` directly.
* `is_event_covered`. Since consolidation can leave the OS dir different from any user request, event filtering now walks ancestors instead of doing a direct hash lookup.
* Consolidated pre-open. `apply_staged` no longer does a per-path `pre_open_tracked_parent`, which caused N opens that consolidation usually threw away. A single `pre_open_consolidated` pass runs the same consolidation trie over staged parents and opens the consolidated set directly, so the later `rebuild_watch_handles` usually finds handles already in place, with no close-and-reopen. This preserves the Windows metadata quirk fix: a directory's `metadata()` must run after its parent is watched, or the parent's later `FILE_ACTION_MODIFIED` is silently dropped.

### Benchmarks

A new `windows_sibling_subdirs` workload watches N sibling directories under a shared parent. This is the shape issue #62 describes, for example per-package or per-dependency directories in a monorepo. The existing `windows_paths_mut` bench hid consolidation's benefit because 40% of its files sit directly in the tempdir root, collapsing everything into one recursive watch.

The `sibling_subdirs` workload was also added for all watcher backends (inotify, fsevents, kqueue, `ReadDirectoryChangesW`, poll). Existing `paths_mut` file counts were lowered from `[100, 500, 1000]` to `[100, 200, 400]` to keep runtimes reasonable.

### Results

* `windows_sibling_subdirs` runs 27 to 80% faster with consolidation, scaling with N.
* The consolidated pre-open pass brings the `windows_paths_mut` workload back to par with the no-consolidation baseline (`nonrecursive/100`: 2.60 ms to 2.09 ms, 20% faster), while `windows_sibling_subdirs/nonrecursive/500` improved from 11.92 ms to 9.25 ms (22% faster).